### PR TITLE
Podman pull prep

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -315,8 +315,11 @@ async fn upgrade(opts: UpgradeOpts) -> Result<()> {
             crate::deploy::stage(sysroot, &osname, &fetched, &spec).await?;
             changed = true;
             if let Some(prev) = booted_image.as_ref() {
-                let diff = ostree_container::ManifestDiff::new(&prev.manifest, &fetched.manifest);
-                diff.print();
+                if let Some(fetched_manifest) = fetched.get_manifest(repo)? {
+                    let diff =
+                        ostree_container::ManifestDiff::new(&prev.manifest, &fetched_manifest);
+                    diff.print();
+                }
             }
         }
     }


### PR DESCRIPTION
Move pull code into deploy

Prep for a podman backend; also we should thin out the logic in
`cli.rs`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

deploy: Change pull function to take sysroot

Prep for a podman backend, where we will write outside of the
ostree repo.

Signed-off-by: Colin Walters <walters@verbum.org>

---

deploy: Pass around subset of ostree-container image state

Prep for a podman backend.

Signed-off-by: Colin Walters <walters@verbum.org>

---

