### PR TITLE
man/bootc-rollback: add information about /etc

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use clap::ValueEnum;
 use composefs::fsverity;
 use fn_error_context::context;
+use indoc::indoc;
 use ostree::gio;
 use ostree_container::store::PrepareResult;
 use ostree_ext::container as ostree_container;
@@ -518,6 +519,18 @@ pub(crate) enum Opt {
     ///
     /// A systemd journal message will be logged with `MESSAGE_ID=26f3b1eb24464d12aa5e7b544a6b5468` in
     /// order to detect a rollback invocation.
+    #[command(after_help = indoc! {r#"
+        Note on Rollbacks and the `/etc` Directory:
+
+        When you perform a rollback (e.g., with `bootc rollback`), any
+        changes made to files in the `/etc` directory won’t carry over
+        to the rolled-back deployment.  The `/etc` files will revert
+        to their state from that previous deployment instead.
+
+        This is because `bootc rollback` just reorders the existing
+        deployments. It doesn't create new deployments. The `/etc`
+        merges happen when new deployments are created.
+    "#})]
     Rollback(RollbackOpts),
     /// Apply full changes to the host specification.
     ///


### PR DESCRIPTION
This is just adding the docs added on https://gitlab.com/fedora/bootc/docs/-/merge_requests/90 to the man page.