### PR TITLE
rename back to --json-fd and unhide

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -38,8 +38,10 @@ pub(crate) struct ProgressOptions {
     ///
     /// Interactive progress will be written to this file descriptor as "JSON lines"
     /// format, where each value is separated by a newline.
-    #[clap(long, hide = true)]
-    pub(crate) progress_fd: Option<RawProgressFd>,
+    /// 
+    /// The format is experimental and may be removed after a small deprecation period.
+    #[clap(long)]
+    pub(crate) json_fd: Option<RawProgressFd>,
 }
 
 impl TryFrom<ProgressOptions> for ProgressWriter {
@@ -47,7 +49,7 @@ impl TryFrom<ProgressOptions> for ProgressWriter {
 
     fn try_from(value: ProgressOptions) -> Result<Self> {
         let r = value
-            .progress_fd
+            .json_fd
             .map(TryInto::try_into)
             .transpose()?
             .unwrap_or_default();


### PR DESCRIPTION
We will use this PR going forward until the API stabilizes.

If the option is hidden, it cannot be used. The option being called `--json-fd` and under our control gives you the option to change the API once more before the next release (this PR should not be merged).

The rename also saves me from having to deal with the drift of migrating to the new version while the old version is still deployed.

Closes: https://github.com/bootc-dev/bootc/issues/1181