### PR TITLE
status: Drop nanoseconds from time

### DIFF
--- a/lib/src/fixtures/spec-staged-booted.yaml
+++ b/lib/src/fixtures/spec-staged-booted.yaml
@@ -15,7 +15,8 @@ status:
         transport: registry
         signature: insecure
       version: nightly
-      timestamp: 2023-10-14T19:22:15Z
+      # This one has nanoseconds, which should be dropped for human consumption
+      timestamp: 2023-10-14T19:22:15.42Z
       imageDigest: sha256:16dc2b6256b4ff0d2ec18d2dbfb06d117904010c8cf9732cdb022818cf7a7566
     incompatible: false
     pinned: false


### PR DESCRIPTION
This is just irrelevant noise; nanoseconds never matter for container builds. Motivated by just making this look visually nicer.

In the future I'd like to look at rendering this how e.g. systemd does it also including a "; 1 day ago" humantime suffix.