### PR TITLE
GOVERNANCE: Add Governance doc for CNCF onboarding

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,152 @@
+# Bootc Project Governance
+
+The Bootc project is dedicated to providing transactional, in-place operating system updates using OCI/Docker container images.
+This governance explains how the project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifications](#modifying-this-charter)
+
+## Values
+
+The Bootc and its leadership embrace the following values:
+
+* Openness: Communication and decision-making happens in the open and is discoverable for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+Bootc Maintainers have "gated" write acess to the [project GitHub repository](https://github.com/bootc-dev/bootc).
+The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md).
+
+Direct pushes to the code is never allowed. All pull requests require review by a maintainer
+*other* than the one submitting it. "Large" changes are encouraged to have a tracking
+issue filed beforehand and gather consensus from multiple maintainers and interested community.
+
+Maintainers collectively manage the project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the Bootc project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which
+is the governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews for 6 months or more,
+    * perform reviews for 20 non-trivial pull requests,
+    * contribute 10 non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+
+A new Maintainer must be proposed by an existing maintainer by opening a PR against the [MAINTAINERS.md](./MAINTAINERS.md), which will prompt a [gitvote](https://github.com/cncf/gitvote). A simple majority vote of existing Maintainers
+approves the application.  Maintainers nominations will be evaluated without prejudice
+to employer or demographics.
+
+Maintainers who are selected will be granted the necessary GitHub rights.
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Inactivity is defined as a period of very low or no activity in the project 
+for a year or more, with no definite schedule to return to full Maintainer 
+activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus
+status.  Emeritus Maintainers will still be consulted on some project matters,
+and can be rapidly returned to Maintainer status if their availability changes.
+This requires two votes from active maintainers.
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+developer meeting, which occurs at 3:30 PM ET on Thursdays via [Zoom](TODO).
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, either in the
+[bootc discussions](https://github.com/bootc-dev/bootc/discussions), or during a
+meeting.  A simple majority of Maintainers approves the request.  The Maintainers
+may also choose to delegate working with the CNCF to non-Maintainer community
+members, who will then be added to the [CNCF's Maintainer List](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+for that purpose.
+
+## Code of Conduct
+
+[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+violations by community members will be discussed and resolved
+by the maintainers privately.  If a Maintainer is directly involved
+in the report, the Maintainers will instead designate two Maintainers to work
+with the CNCF Code of Conduct Committee in resolving it.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves.  If this
+responsibility is delegated, the Maintainers will appoint a team of at least two 
+contributors to handle it.  The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](./SECURITY.md).
+
+## Voting
+
+While most business in Bootc is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+periodically the Maintainers may need to vote on specific actions or changes.
+A vote can be taken using [gitvote](https://github.com/cncf/gitvote) or
+privately for security or conduct matters. Any Maintainer may demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where
+otherwise noted.  Two-thirds majority votes mean at least two-thirds of all 
+existing maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by 
+a 2/3 vote of the Maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a potential security vulnerability in bootc, please report it by following these steps:
+
+### 1. **Use the GitHub Security Tab**
+This repository is set up to allow vulnerability reports through GitHub's Security Advisories feature. To report a vulnerability:
+
+1. Navigate to the repository's main page.
+2. Select the [**Security**](https://github.com/bootc-dev/bootc/security) tab.
+3. Select **Advisories** from the left-hand sidebar.
+4. Click on **Report a vulnerability**.
+5. Fill in the required details and submit the report.
+
+Following this process will create a private advisory for our maintainers to review.
+
+### 2. **Do Not Open Public Pull Requests, Issues, or Discussions**
+Please **do not** discuss the issue, create PRs, or start discussions about the vulnerability. This ensures the vulnerability is not widely exploited before a fix is provided.


### PR DESCRIPTION
This is what Podman uses, with a couple of removed rules and replacing Podman for Bootc.

However, the more I read it, it seems like too much process vs the contributor size we have currently.

I am trying to find another project example that is a little bit in line with our current process.


I do like this: https://github.com/flatcar/Flatcar/blob/main/governance.md a bit more. Is basically maintainers group and that's it. I think we should expand that a bit into maintainers and core maintainers. Where core maintainers deal with tie breakers and final decision ends up if we can't get lazy consensus or consensus.


I will try to use these two as prior art if the above goal looks good to you all.