### PR TITLE
imgstorage: Set selinux labels for imgstorage

### DIFF
--- a/lib/src/boundimage.rs
+++ b/lib/src/boundimage.rs
@@ -148,11 +148,11 @@ pub(crate) async fn pull_images(
     sysroot: &Storage,
     bound_images: Vec<crate::boundimage::BoundImage>,
 ) -> Result<()> {
-    // Only do work like initializing the image storage if we have images to pull.
+    // Always initialize the img store to ensure labels are set when upgrading
+    let imgstore = sysroot.get_ensure_imgstore()?;
     if bound_images.is_empty() {
         return Ok(());
     }
-    let imgstore = sysroot.get_ensure_imgstore()?;
     pull_images_impl(imgstore, bound_images).await
 }
 

--- a/tests/booted/test-logically-bound-install.nu
+++ b/tests/booted/test-logically-bound-install.nu
@@ -35,7 +35,15 @@ def test_bootc_image_list [] {
     validate_images $images
 }
 
+def test_storage_labels [] {
+    let root_labeled = getfattr -n security.selinux /var/lib/containers/storage | grep container_var_lib_t | complete
+    assert equal $root_labeled.exit_code 0
+    let overlay_labeled = getfattr -n security.selinux /usr/lib/bootc/storage/overlay | grep container_ro_file_t | complete
+    assert equal $overlay_labeled.exit_code 0
+}
+
 test_logically_bound_images_in_storage
 test_bootc_image_list
+test_storage_labels
 
 tap ok


### PR DESCRIPTION
Running some containers (e.g. mssql) requires the imgstorage labels to
be identical to the /var/lib/containers/storage. The ideal long term
solution to this is to ship a policy with bootc to be included in each
bootc image that handles the mapping. As a near term solution, this
commit creates each subdirectory of /sysroot/ostree/bootc/storage, sets
the label of each directory directly, then runs `podman --root ...
images` to populate the storage directory with all the correct labels
set. The reason for directly setting the labels rather than inferring
them from /var/lib/containers in an existing policy, is to avoid
requiring a policy when initializing the storage directory in other
places than the install to filesystem path (e.g. anaconda).

---

this ballooned into more changes than I expected. I'm not sure if directly setting the label is what we want, but I was having a hard time finding a way to access a policy to use in the [anaconda](https://github.com/bootc-dev/bootc/blob/57adb67bf0a884a5cd06576713bf9e058dc708e5/lib/src/install/completion.rs#L294) installation path, or the [image cli stuff](https://github.com/bootc-dev/bootc/blob/57adb67bf0a884a5cd06576713bf9e058dc708e5/lib/src/cli.rs#L1101).