### PR TITLE
feat(rollback): add `--apply` flag

### DIFF
--- a/docs/src/man/bootc-rollback.md
+++ b/docs/src/man/bootc-rollback.md
@@ -7,7 +7,7 @@ queued upgrade) then it will be discarded
 
 # SYNOPSIS
 
-**bootc rollback** \[**-h**\|**\--help**\]
+**bootc rollback**  \[**\--apply**\] \[**-h**\|**\--help**\]
 
 # DESCRIPTION
 
@@ -27,6 +27,14 @@ A systemd journal message will be logged with
 rollback invocation.
 
 # OPTIONS
+
+**\--apply**
+
+:   Restart or reboot into the rollback image.
+
+    Currently, this option always reboots. In the future this command
+    will detect the case where no kernel changes are queued, and perform
+    a userspace-only restart.
 
 **-h**, **\--help**
 


### PR DESCRIPTION
Adds an --apply flag to the `bootc rollback` command to implement automated restarts.

Have confirmed this works by building the bootc binary and running `bootc rollback --apply` on my host.  This restarted the machine into the new (rollback) image.

Closes #1029

---

Hope you don't mind I took the easiest issue I could find :) 
This was mainly to familiarise myself with the debugging flow, and to get an environment setup.

The implementation was referencing the existing --apply flag for the switch command.  The error handling _should_ be okay, since if I understand correctly, the `?` prepended to the `crate::deploy::rollback(sysroot).await` will cause the function to work the same as it did previously - returning the error to the calling function inside a Result.

How do the docs changes work?  They look like they would be auto-generated, though I couldn't find a target to do so.