### PR TITLE
ci: Build Copr build with Packit

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,0 @@
-srpm:
-	dnf -y install 'dnf5-command(builddep)'
-	dnf -y install dnf-utils git
-	# similar to https://github.com/actions/checkout/issues/760, but for COPR
-	git config --global --add safe.directory '*'
-	dnf -y builddep ./contrib/packaging/bootc.spec
-	cargo install cargo-vendor-filterer
-	cargo xtask package-srpm
-	mv target/*.src.rpm $$outdir

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,6 +55,17 @@ jobs:
       # - rhel-9-x86_64
       # - rhel-9-aarch64
 
+  # Build on new commit to main branch
+  - job: copr_build
+    trigger: commit
+    branch: main
+    owner: rhcontainerbot
+    project: bootc
+    enable_net: true
+    notifications:
+      failure_comment:
+        message: "bootc Copr build failed for {commit_sha}. @admin check logs {logs_url} and packit dashboard {packit_dashboard_url}"
+
   - job: tests
     trigger: pull_request
     targets:


### PR DESCRIPTION
After movement, the Copr build does not work. Taking this failure fix, we can use Packit to build Copr build. So we do not need to update `.copr/Makefile` when build code changed. And we can remove `.copr` folder.

[Packit can build Copr build in custom Copr project](https://packit.dev/docs/configuration/upstream/copr_build#using-a-custom-copr-project)

