### PR TITLE
fix(status): enable --booted option to only show the current deployment

### DIFF
--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -7,7 +7,7 @@ use ostree_ext::oci_spec::image::Digest;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::k8sapitypes;
+use crate::{k8sapitypes, status::Slot};
 
 const API_VERSION: &str = "org.containers.bootc/v1";
 const KIND: &str = "BootcHost";
@@ -176,6 +176,24 @@ impl Host {
             },
             spec,
             status: Default::default(),
+        }
+    }
+
+    /// Filter out the requested slot
+    pub fn filter_to_slot(&mut self, slot: Slot) {
+        match slot {
+            Slot::Staged => {
+                self.status.booted = None;
+                self.status.rollback = None;
+            }
+            Slot::Booted => {
+                self.status.staged = None;
+                self.status.rollback = None;
+            }
+            Slot::Rollback => {
+                self.status.staged = None;
+                self.status.booted = None;
+            }
         }
     }
 }


### PR DESCRIPTION
The existing code didn't take into account the --booted option, so always showed the staged, current and rollback deployments.  This correctly wires through the --booted option to only show that deployment.

Stubs have been left in the code should we wish to enable options to show only the rollback or staged options (--rollback / --staged).

I tried to make the implementation not specific to --booted, so added the Slot enum as an input.  This meant making that enum public.  Please let me know if you would prefer a different approach.

No docs changes were required since the flag is already present.

Please find below the different outputs:

<details>

```
bootc-status-booted-only on  bootc-status-booted-only via 🦀 took 2s 
❯ sudo ./target/debug/bootc status --booted
[sudo] password for admin: 
● Booted image: ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open
        Digest: sha256:82de1647a00fd1f7674d268c9aaa33127a09139ac3206c5d71c8e0926846304d
       Version: 250317 (2025-03-17T01:45:07Z)

bootc-status-booted-only on  bootc-status-booted-only via 🦀 took 3s 
❯ sudo ./target/debug/bootc status         
● Booted image: ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open
        Digest: sha256:82de1647a00fd1f7674d268c9aaa33127a09139ac3206c5d71c8e0926846304d
       Version: 250317 (2025-03-17T01:45:07Z)

  Rollback image: ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open
          Digest: sha256:2b6be3a574af416fa7adb8a1217e408aabe18ab15e6e9a401e180a9d1b40bb44
         Version: 250315 (2025-03-15T01:45:07Z)

bootc-status-booted-only on  bootc-status-booted-only via 🦀 
❯ sudo ./target/debug/bootc status --json  
{"apiVersion":"org.containers.bootc/v1","kind":"BootcHost","metadata":{"name":"host"},"spec":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"bootOrder":"default"},"status":{"staged":null,"booted":{"image":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"version":"250317","timestamp":"2025-03-17T01:45:07Z","imageDigest":"sha256:82de1647a00fd1f7674d268c9aaa33127a09139ac3206c5d71c8e0926846304d"},"cachedUpdate":null,"incompatible":false,"pinned":false,"store":"ostreeContainer","ostree":{"checksum":"bf1483336d5d20bd453c07606c65066147eec7149b3f8b269c8f4d167df8d2f3","deploySerial":0}},"rollback":{"image":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"version":"250315","timestamp":"2025-03-15T01:45:07Z","imageDigest":"sha256:2b6be3a574af416fa7adb8a1217e408aabe18ab15e6e9a401e180a9d1b40bb44"},"cachedUpdate":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"version":"250317","timestamp":"2025-03-17T01:45:07Z","imageDigest":"sha256:82de1647a00fd1f7674d268c9aaa33127a09139ac3206c5d71c8e0926846304d"},"incompatible":false,"pinned":false,"store":"ostreeContainer","ostree":{"checksum":"6fb01556d574856633568b7db7b5760f0b23890f510e0da05dcaadc3023c2443","deploySerial":0}},"rollbackQueued":false,"type":"bootcHost"}}%                                                                                                                   
bootc-status-booted-only on  bootc-status-booted-only via 🦀 
❯ sudo ./target/debug/bootc status --booted --json
{"apiVersion":"org.containers.bootc/v1","kind":"BootcHost","metadata":{"name":"host"},"spec":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"bootOrder":"default"},"status":{"staged":null,"booted":{"image":{"image":{"image":"ghcr.io/rsturla/eternal-linux/lumina:stable-nvidia-open","transport":"registry","signature":"containerPolicy"},"version":"250317","timestamp":"2025-03-17T01:45:07Z","imageDigest":"sha256:82de1647a00fd1f7674d268c9aaa33127a09139ac3206c5d71c8e0926846304d"},"cachedUpdate":null,"incompatible":false,"pinned":false,"store":"ostreeContainer","ostree":{"checksum":"bf1483336d5d20bd453c07606c65066147eec7149b3f8b269c8f4d167df8d2f3","deploySerial":0}},"rollback":null,"rollbackQueued":false,"type":"bootcHost"}}%                                                                                                                                          

```

</details>

Closes #465

---

This is my first "real" Rust PR, so please be harsh.