### PR TITLE
lsm, imgstorage: Rework relabeling

### DIFF
--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -230,8 +230,11 @@ pub(crate) fn has_security_selinux(root: &Dir, path: &Utf8Path) -> Result<SELinu
     }
 }
 
+/// Directly set the `security.selinux` extended atttribute on the target
+/// path. Symbolic links are not followed for the target.
+///
+/// Note that this API will work even if SELinux is disabled.
 pub(crate) fn set_security_selinux_path(root: &Dir, path: &Utf8Path, label: &[u8]) -> Result<()> {
-    // TODO: avoid hardcoding a max size here
     let fdpath = format!("/proc/self/fd/{}/", root.as_raw_fd());
     let fdpath = &Path::new(&fdpath).join(path);
     rustix::fs::lsetxattr(
@@ -243,6 +246,9 @@ pub(crate) fn set_security_selinux_path(root: &Dir, path: &Utf8Path, label: &[u8
     Ok(())
 }
 
+/// Given a policy, ensure the target file path has a security.selinux label.
+/// If the path already is labeled, this function is a no-op, even if
+/// the policy would default to a different label.
 pub(crate) fn ensure_labeled(
     root: &Dir,
     path: &Utf8Path,

--- a/tests/booted/readonly/020-test-relabel.nu
+++ b/tests/booted/readonly/020-test-relabel.nu
@@ -1,0 +1,26 @@
+use std assert
+use tap.nu
+
+tap begin "Relabel"
+
+let td = mktemp -d -p /var/tmp
+cd $td
+
+mkdir etc/ssh
+touch etc/shadow etc/ssh/ssh_config
+bootc internals relabel --as-path /etc $"(pwd)/etc"
+
+def assert_labels_equal [p] {
+    let base = (getfattr --only-values -n security.selinux $"/($p)")
+    let target = (getfattr --only-values -n security.selinux $p)
+    assert equal $base $target
+}
+
+for path in ["etc", "etc/shadow", "etc/ssh/ssh_config"] {
+    assert_labels_equal $path
+}
+
+cd /
+rm -rf $td
+
+tap ok


### PR DESCRIPTION
lsm: Add some more comments

No functional changes.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lsm, imgstorage: Rework relabeling

The previous work here wasn't quite right in a few ways.
Our LSM/SELinux code is a bit complex and under-tested.

Here we:

First, refactor some of the labeling bits so we have a clean
"relabel this file" API.

For the bootc-owned containers-storage we don't want
"recursive create dir and relabel" in the general case - we
need to handle upgrades, where there are definitely
non-directories too.

Hence rework the API to just be a clean recursive
relabeling pass, don't attempt to create anything.

While we're here:

- Rework the recursive traversal to operate on shared
  single `&mut` path buffers to avoid a heap alloc per directory.
- Add a `bootc internals relabel` CLI verb that
  makes it easy to test this code both interactively
  and in integration testing.
- Add a test case

Closes: https://github.com/bootc-dev/bootc/issues/1219

Signed-off-by: Colin Walters <walters@verbum.org>

---