### PR TITLE
Comment tidy up from #1228

### DIFF
--- a/ostree-ext/src/tar/write.rs
+++ b/ostree-ext/src/tar/write.rs
@@ -367,16 +367,18 @@ async fn filter_tar_async(
 
         let r = filter_tar(&mut src, dest, &config, &repo_tmpdir);
 
-        // We need to make sure to flush out the decompressor here,
-        // otherwise it's possible that we finish processing the tar
-        // stream but leave data in the pipe.  For example,
-        // zstd:chunked layers will have metadata/skippable frames at
-        // the end of the stream.  That data isn't relevant to the tar
-        // stream, but if we don't read it here then on the skopeo
-        // proxy we'll block trying to write the end of the stream.
-        // That in turn will block our client end trying to call
-        // FinishPipe, and we end up deadlocking ourselves through
-        // skopeo.
+        // We need to make sure to flush out the decompressor and/or
+        // tar stream here.  For tar, we might not read through the
+        // entire stream, because the archive has zero-block-markers
+        // at the end; or possibly because the final entry is filtered
+        // in filter_tar so we don't advance to read the data.  For
+        // decompressor, zstd:chunked layers will have
+        // metadata/skippable frames at the end of the stream.  That
+        // data isn't relevant to the tar stream, but if we don't read
+        // it here then on the skopeo proxy we'll block trying to
+        // write the end of the stream.  That in turn will block our
+        // client end trying to call FinishPipe, and we end up
+        // deadlocking ourselves through skopeo.
         //
         // https://github.com/bootc-dev/bootc/issues/1204
         let mut sink = std::io::sink();
@@ -385,7 +387,6 @@ async fn filter_tar_async(
             tracing::debug!("Read extra {n} bytes at end of decompressor stream");
         }
 
-        // Pass ownership of the input stream back to the caller - see below.
         Ok(r)
     });
     let copier = tokio::io::copy(&mut rx_buf, &mut dest);


### PR DESCRIPTION
This merged before I pushed an updated version, so follow up:

- Be explicit about also flushing the tar stream, since that can also
  have trailing data.

- Remove unneeded comment about passing the input stream

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
