### PR TITLE
docs: install to-disk --via-loopback requires root

### DIFF
--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -184,8 +184,7 @@ does not do this today, in the future it may automatically migrate
 ### Using `bootc install to-disk --via-loopback`
 
 Because every `bootc` system comes with an opinionated default installation
-process, you can create a raw disk image (that can e.g. be booted via virtualization)
-via e.g.:
+process, you can create a raw disk image that you can boot via virtualization. Run these commands as root:
 
 ```bash
 truncate -s 10G myimage.raw


### PR DESCRIPTION
Update the `--via-loopback` example to clarify that this must be run as root.

We already state this at the very top of this document, but this makes it clearer for users who skip directly down to this example command.
