### PR TITLE
spec, status: Add architecture

### DIFF
--- a/lib/src/fixtures/spec-only-booted.yaml
+++ b/lib/src/fixtures/spec-only-booted.yaml
@@ -14,6 +14,7 @@ status:
       image:
         image: quay.io/centos-bootc/centos-bootc:stream9
         transport: registry
+      architecture: arm64
       version: stream9.20240807.0
       timestamp: null
       imageDigest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38

--- a/lib/src/fixtures/spec-ostree-remote.yaml
+++ b/lib/src/fixtures/spec-ostree-remote.yaml
@@ -14,6 +14,7 @@ status:
       image:
         image: quay.io/otherexample/otherimage:latest
         transport: registry
+      architecture: arm64
       version: 20231230.1
       timestamp: 2023-12-30T16:10:11Z
       imageDigest: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c

--- a/lib/src/fixtures/spec-ostree-to-bootc.yaml
+++ b/lib/src/fixtures/spec-ostree-to-bootc.yaml
@@ -13,6 +13,7 @@ status:
       image:
         image: quay.io/centos-bootc/centos-bootc:stream9
         transport: registry
+      architecture: s390x
       version: stream9.20240807.0
       timestamp: null
       imageDigest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38

--- a/lib/src/fixtures/spec-staged-booted.yaml
+++ b/lib/src/fixtures/spec-staged-booted.yaml
@@ -14,6 +14,7 @@ status:
         image: quay.io/example/someimage:latest
         transport: registry
         signature: insecure
+      architecture: arm64
       version: nightly
       # This one has nanoseconds, which should be dropped for human consumption
       timestamp: 2023-10-14T19:22:15.42Z
@@ -29,6 +30,7 @@ status:
         image: quay.io/example/someimage:latest
         transport: registry
         signature: insecure
+      architecture: arm64
       version: nightly
       timestamp: 2023-09-30T19:22:16Z
       imageDigest: sha256:736b359467c9437c1ac915acaae952aad854e07eb4a16a94999a48af08c83c34

--- a/lib/src/fixtures/spec-staged-rollback.yaml
+++ b/lib/src/fixtures/spec-staged-rollback.yaml
@@ -14,6 +14,7 @@ status:
         image: quay.io/example/someimage:latest
         transport: registry
         signature: insecure
+      architecture: s390x
       version: nightly
       timestamp: 2023-10-14T19:22:15Z
       imageDigest: sha256:16dc2b6256b4ff0d2ec18d2dbfb06d117904010c8cf9732cdb022818cf7a7566
@@ -29,6 +30,7 @@ status:
         image: quay.io/example/someimage:latest
         transport: registry
         signature: insecure
+      architecture: s390x
       version: nightly
       timestamp: 2023-09-30T19:22:16Z
       imageDigest: sha256:736b359467c9437c1ac915acaae952aad854e07eb4a16a94999a48af08c83c34

--- a/lib/src/fixtures/spec-v1a1-orig.yaml
+++ b/lib/src/fixtures/spec-v1a1-orig.yaml
@@ -17,6 +17,7 @@ status:
       version: nightly
       timestamp: 2023-10-14T19:22:15Z
       imageDigest: sha256:16dc2b6256b4ff0d2ec18d2dbfb06d117904010c8cf9732cdb022818cf7a7566
+      architecture: amd64
     incompatible: false
     pinned: false
     ostree:
@@ -31,6 +32,7 @@ status:
       version: nightly
       timestamp: 2023-09-30T19:22:16Z
       imageDigest: sha256:736b359467c9437c1ac915acaae952aad854e07eb4a16a94999a48af08c83c34
+      architecture: amd64
     incompatible: false
     pinned: false
     ostree:

--- a/lib/src/fixtures/spec-v1a1.yaml
+++ b/lib/src/fixtures/spec-v1a1.yaml
@@ -13,6 +13,7 @@ status:
       image:
         image: quay.io/otherexample/otherimage:latest
         transport: registry
+      architecture: s390x
       version: 20231230.1
       timestamp: 2023-12-30T16:10:11Z
       imageDigest: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c

--- a/lib/src/fixtures/spec-via-local-oci.yaml
+++ b/lib/src/fixtures/spec-via-local-oci.yaml
@@ -14,6 +14,7 @@ status:
       image:
         image: /var/mnt/osupdate
         transport: oci
+      architecture: amd64
       version: stream9.20240807.0
       timestamp: null
       imageDigest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38

--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -101,6 +101,8 @@ pub struct ImageStatus {
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
     /// The digest of the fetched image (e.g. sha256:a0...);
     pub image_digest: String,
+    /// The hardware architecture of this image
+    pub architecture: String,
 }
 
 /// A bootable entry

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -381,9 +381,10 @@ fn human_render_imagestatus(
     let prefix_len = prefix.chars().count();
     writeln!(out, "{prefix}: {imageref}")?;
 
+    let arch = image.architecture.as_str();
     write_row_name(&mut out, "Digest", prefix_len)?;
     let digest = &image.image_digest;
-    writeln!(out, "{digest}")?;
+    writeln!(out, "{digest} ({arch})")?;
 
     // Format the timestamp without nanoseconds since those are just irrelevant noise for human
     // consumption - that time scale should basically never matter for container builds.
@@ -477,11 +478,11 @@ mod tests {
             .expect("No spec found");
         let expected = indoc::indoc! { r"
             Staged image: quay.io/example/someimage:latest
-                  Digest: sha256:16dc2b6256b4ff0d2ec18d2dbfb06d117904010c8cf9732cdb022818cf7a7566
+                  Digest: sha256:16dc2b6256b4ff0d2ec18d2dbfb06d117904010c8cf9732cdb022818cf7a7566 (arm64)
                  Version: nightly (2023-10-14T19:22:15Z)
         
           ● Booted image: quay.io/example/someimage:latest
-                  Digest: sha256:736b359467c9437c1ac915acaae952aad854e07eb4a16a94999a48af08c83c34
+                  Digest: sha256:736b359467c9437c1ac915acaae952aad854e07eb4a16a94999a48af08c83c34 (arm64)
                  Version: nightly (2023-09-30T19:22:16Z)
         "};
         similar_asserts::assert_eq!(w, expected);
@@ -511,7 +512,7 @@ mod tests {
             .expect("No spec found");
         let expected = indoc::indoc! { r"
             Staged image: quay.io/centos-bootc/centos-bootc:stream9
-                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38
+                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38 (s390x)
                  Version: stream9.20240807.0
           
           ● Booted ostree
@@ -527,7 +528,7 @@ mod tests {
             .expect("No spec found");
         let expected = indoc::indoc! { r"
           ● Booted image: quay.io/centos-bootc/centos-bootc:stream9
-                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38
+                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38 (arm64)
                  Version: stream9.20240807.0
         "};
         similar_asserts::assert_eq!(w, expected);
@@ -548,7 +549,7 @@ mod tests {
             .unwrap();
         let expected = indoc::indoc! { r"
           ● Booted image: oci:/var/mnt/osupdate
-                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38
+                  Digest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38 (amd64)
                  Version: stream9.20240807.0
         "};
         similar_asserts::assert_eq!(w, expected);

--- a/lib/src/store/ostree_container.rs
+++ b/lib/src/store/ostree_container.rs
@@ -55,11 +55,13 @@ fn create_imagestatus(
         .and_then(try_deserialize_timestamp);
 
     let version = ostree_container::version_for_config(config).map(ToOwned::to_owned);
+    let architecture = config.architecture().to_string();
     ImageStatus {
         image,
         version,
         timestamp,
         image_digest: manifest_digest.to_string(),
+        architecture,
     }
 }
 


### PR DESCRIPTION
The argument here twofold:

- We used to show it with ostree refs because ostree doesn't have manifest lists
- Actually we do want to highlight that the digest of the image is always the digest of the per-arch image; we currently peel and discard manifest lists, which may not be obvious.

Closes: https://github.com/bootc-dev/bootc/issues/1238