### PR TITLE
Update to use walk from cap-std-ext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,14 +365,14 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "4.0.5"
+version = "4.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6312927ec94cf0d277f2aa42ab5fe92b8c1a4c1fa81f119c302bd5b0b46790"
+checksum = "7770022cf9ca0e804cdc7725fa6be84a3721e5733ba889b3300689dcdb407fa1"
 dependencies = [
  "cap-primitives",
  "cap-tempfile",
  "libc",
- "rustix 0.38.44",
+ "rustix 1.0.3",
 ]
 
 [[package]]

--- a/tests-integration/src/install.rs
+++ b/tests-integration/src/install.rs
@@ -1,7 +1,5 @@
-use std::{
-    os::fd::AsRawFd,
-    path::{Path, PathBuf},
-};
+use std::os::fd::AsRawFd;
+use std::path::Path;
 
 use anyhow::Result;
 use camino::Utf8Path;
@@ -147,8 +145,7 @@ pub(crate) fn run_alongside(image: &str, mut testargs: libtest_mimic::Arguments)
             cmd!(sh, "sudo {BASE_ARGS...} {image} bootc install to-existing-root --acknowledge-destructive {generic_inst_args...}").run()?;
             generic_post_install_verification()?;
             let root = &Dir::open_ambient_dir("/ostree", cap_std::ambient_authority()).unwrap();
-            let mut path = PathBuf::from(".");
-            crate::selinux::verify_selinux_recurse(root, &mut path, false)?;
+            crate::selinux::verify_selinux_recurse(root, false)?;
             Ok(())
         }),
         Trial::test("Install to non-default stateroot", move || {

--- a/tests-integration/src/tests-integration.rs
+++ b/tests-integration/src/tests-integration.rs
@@ -1,7 +1,5 @@
 //! Integration tests.
 
-use std::path::PathBuf;
-
 use camino::Utf8PathBuf;
 use cap_std_ext::cap_std::{self, fs::Dir};
 use clap::Parser;
@@ -53,8 +51,7 @@ fn main() {
         Opt::RunVM(opts) => runvm::run(opts),
         Opt::VerifySELinux { rootfs, warn } => {
             let root = &Dir::open_ambient_dir(&rootfs, cap_std::ambient_authority()).unwrap();
-            let mut path = PathBuf::from(".");
-            selinux::verify_selinux_recurse(root, &mut path, warn)
+            selinux::verify_selinux_recurse(root, warn)
         }
     };
     if let Err(e) = r {


### PR DESCRIPTION
Depends: https://github.com/coreos/cap-std-ext/pull/66

---

We have a few code paths which are doing a recursive filesystem
walk and it's much easier with an API like this, especially
when one wants to keep track of the full relative path.

Signed-off-by: Colin Walters <walters@verbum.org>