### PR TITLE
Add OpenSSF Best Practices badge

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,5 +8,5 @@ The current Maintainers Group for the bootc Project consists of:
 | Colin Walters     | [cgwalters](https://github.com/orgs/bootc-dev/people/cgwalters)      | Red Hat         | Approver         |
 | John Eckersberg   | [jeckersb](https://github.com/orgs/bootc-dev/people/jeckersb)        | Red Hat         | Approver         |
 | Xiaofeng Wang     | [henrywang](https://github.com/orgs/bootc-dev/people/henrywang)      | Red Hat         | Approver         |
-| Gursewak Mangat   | [gurusewak](https://github.com/orgs/bootc-dev/people/gursewak1997)   | Red Hat         | Approver         |
+| Gursewak Mangat   | [gursewak1997](https://github.com/orgs/bootc-dev/people/gursewak1997)| Red Hat         | Approver         |
 | Joseph Marrero    | [jmarrero](https://github.com/orgs/bootc-dev/people/jmarrero)        | Red Hat         | Approver         |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ There is also a list of [MAINTAINERS.md](MAINTAINERS.md).
 
 ## Governance
 
+## Badges
+
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10113/badge)](https://www.bestpractices.dev/projects/10113)
+
+
 ### Code of Conduct
 
 The bootc project is a [Cloud Native Computing Foundation (CNCF) Sandbox project](https://www.cncf.io/sandbox-projects/)


### PR DESCRIPTION
Add OpenSSF Best Practices badge and fix a name typo in Maintainers list.