### PR TITLE
various: adapt to new composefs-rs fsverity API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -500,22 +502,27 @@ dependencies = [
 [[package]]
 name = "composefs"
 version = "0.2.0"
-source = "git+https://github.com/containers/composefs-rs?rev=55ae2e9ba72f6afda4887d746e6b98f0a1875ac4#55ae2e9ba72f6afda4887d746e6b98f0a1875ac4"
+source = "git+https://github.com/containers/composefs-rs?rev=821eeae93e48f1ee381c49b8cd4d22fda92d27a2#821eeae93e48f1ee381c49b8cd4d22fda92d27a2"
 dependencies = [
  "anyhow",
  "async-compression",
  "clap",
  "containers-image-proxy",
+ "env_logger 0.11.6",
  "hex",
  "indicatif",
+ "log",
  "oci-spec",
  "regex-automata 0.4.9",
- "rustix 0.38.44",
+ "rustix 1.0.3",
+ "serde",
  "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "toml",
+ "xxhash-rust",
  "zerocopy 0.8.23",
  "zstd",
 ]
@@ -723,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +753,19 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1086,6 +1116,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"
@@ -1782,7 +1818,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
  "rand",
 ]
@@ -2877,6 +2913,12 @@ dependencies = [
  "toml",
  "xshell",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 [licenses]
 allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT",
          "BSD-3-Clause", "BSD-2-Clause", "Zlib",
-         "Unlicense", "CC0-1.0",
+         "Unlicense", "CC0-1.0", "BSL-1.0",
          "Unicode-DFS-2016", "Unicode-3.0"]
 private = { ignore = true }
 

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1197,8 +1197,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 FsverityOpts::Measure { path } => {
                     let fd =
                         std::fs::File::open(&path).with_context(|| format!("Reading {path}"))?;
-                    let digest =
-                        fsverity::measure_verity_digest::<_, fsverity::Sha256HashValue>(&fd)?;
+                    let digest: fsverity::Sha256HashValue = fsverity::measure_verity(&fd)?;
                     let digest = hex::encode(digest);
                     println!("{digest}");
                     Ok(())
@@ -1206,7 +1205,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 FsverityOpts::Enable { path } => {
                     let fd =
                         std::fs::File::open(&path).with_context(|| format!("Reading {path}"))?;
-                    fsverity::ioctl::fs_ioc_enable_verity::<_, fsverity::Sha256HashValue>(&fd)?;
+                    fsverity::enable_verity::<fsverity::Sha256HashValue>(&fd)?;
                     Ok(())
                 }
             },

--- a/lib/src/fsck.rs
+++ b/lib/src/fsck.rs
@@ -164,7 +164,7 @@ fn verity_state_of_objects(
         };
         let f = d.open(&name)?;
         let r: Option<composefs::fsverity::Sha256HashValue> =
-            composefs::fsverity::ioctl::fs_ioc_measure_verity(f.as_fd())?;
+            composefs::fsverity::measure_verity_opt(f.as_fd())?;
         drop(f);
         if r.is_some() {
             enabled += 1;

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -20,7 +20,7 @@ ostree = { features = ["v2025_1"], version = "0.20.0" }
 anyhow = { workspace = true }
 bootc-utils = { path = "../utils" }
 camino = { workspace = true, features = ["serde1"] }
-composefs = { git = "https://github.com/containers/composefs-rs", rev = "55ae2e9ba72f6afda4887d746e6b98f0a1875ac4" }
+composefs = { git = "https://github.com/containers/composefs-rs", rev = "821eeae93e48f1ee381c49b8cd4d22fda92d27a2" }
 chrono = { workspace = true }
 olpc-cjson = "0.1.1"
 clap = { workspace = true, features = ["derive","cargo"] }


### PR DESCRIPTION
~...and a bunch of probably-unnecessary changes to cargo lockfiles~

~Don't merge this yet: the composefs-rs revision isn't merged yet.~

 - [x] https://github.com/containers/composefs-rs/pull/102
 - [x] investigate version requirements in composefs-rs: https://github.com/containers/composefs-rs/pull/103
 - [x] update composefs-rs revision in this PR