### PR TITLE
test: Use to-existing-root --acknowledge-destructive

### DIFF
--- a/tmt/tests/test-00-bootc-install.sh
+++ b/tmt/tests/test-00-bootc-install.sh
@@ -126,7 +126,7 @@ REALEOF
         -v /root/.ssh:/output \
         --security-opt label=type:unconfined_t \
         "localhost/bootc:tmt" \
-        bootc install to-existing-root --target-transport containers-storage
+        bootc install to-existing-root --target-transport containers-storage --acknowledge-destructive
 
     # Reboot
     tmt-reboot


### PR DESCRIPTION
In the test suite, pass the `--acknowledge-destructive` flag to `bootc install to-existing-root` to avoid the 20 second timer.