### PR TITLE
feat(status): display pinned deployments

### DIFF
--- a/lib/src/fixtures/spec-booted-pinned.yaml
+++ b/lib/src/fixtures/spec-booted-pinned.yaml
@@ -1,0 +1,46 @@
+apiVersion: org.containers.bootc/v1alpha1
+kind: BootcHost
+metadata:
+  name: host
+spec:
+  image:
+    image: quay.io/centos-bootc/centos-bootc:stream9
+    transport: registry
+  bootOrder: default
+status:
+  staged: null
+  booted:
+    image:
+      image:
+        image: quay.io/centos-bootc/centos-bootc:stream9
+        transport: registry
+      architecture: arm64
+      version: stream9.20240807.0
+      timestamp: null
+      imageDigest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b38
+    cachedUpdate: null
+    incompatible: false
+    pinned: true
+    ostree:
+      checksum: 439f6bd2e2361bee292c1f31840d798c5ac5ba76483b8021dc9f7b0164ac0f48
+      deploySerial: 0
+      stateroot: default
+  otherDeployments:
+  - image:
+      image:
+        image: quay.io/centos-bootc/centos-bootc:stream9
+        transport: registry
+      version: stream9.20240807.0
+      timestamp: null
+      imageDigest: sha256:47e5ed613a970b6574bfa954ab25bb6e85656552899aa518b5961d9645102b37
+      architecture: arm64
+    cachedUpdate: null
+    incompatible: false
+    pinned: true
+    ostree:
+      checksum: 99b2cc3b6edce9ebaef6a6076effa5ee3e1dcff3523016ffc94a1b27c6c67e12
+      deploySerial: 0
+      stateroot: default
+  rollback: null
+  rollbackQueued: false
+  type: bootcHost

--- a/lib/src/spec.rs
+++ b/lib/src/spec.rs
@@ -203,6 +203,10 @@ pub struct HostStatus {
     pub booted: Option<BootEntry>,
     /// The previously booted image
     pub rollback: Option<BootEntry>,
+    /// Other deployments (i.e. pinned)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub other_deployments: Vec<BootEntry>,
     /// Set to true if the rollback entry is queued for the next boot.
     #[serde(default)]
     pub rollback_queued: bool,


### PR DESCRIPTION
Part of #904

Displays pinned deployments as part of "bootc status".
Includes unit tests to ensure correct parsing of the
pinned deployments, and that they are displayed in
human readable formats correctly.

---

Please find below how they look in both human and machine readable formats.
When the staged, booted or rollback deployments are pinned, the information is _not_ duplicated in the outputs.  

Please let me know if this output format is alright, or if you'd prefer some changes.

Human readable:

```
❯ sudo ./target/debug/bootc status          
[sudo] password for admin: 
● Booted image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        Digest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e (amd64)
       Version: 250507 (2025-05-07T01:44:43Z)
        Pinned: yes

  Rollback image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
          Digest: sha256:6c4d19f8ecc21c055c81d0993921399f0cc034ec69ad49bece9c12f5bb1dddf8 (amd64)
         Version: 250505 (2025-05-05T01:46:41Z)

 Other image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
      Digest: sha256:244bcf3584f5dd9bb424f5dbb0084709c9b68a12299e8242cb4e7fa74e31a7a9 (amd64)
     Version: 250427 (2025-04-27T01:44:43Z)
      Pinned: yes

 Other image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
      Digest: sha256:b1874fbb5f442657f3cc07a547c54292ca3f24fe828ab4f3132df4c9f23f1e3e (amd64)
     Version: 250425 (2025-04-25T01:46:32Z)
      Pinned: yes
```

YAML: 

```
❯ sudo ./target/debug/bootc status --format yaml
apiVersion: org.containers.bootc/v1
kind: BootcHost
metadata:
  name: host
spec:
  image:
    image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
    transport: registry
    signature: containerPolicy
  bootOrder: default
status:
  staged: null
  booted:
    image:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
        signature: containerPolicy
      version: '250507'
      timestamp: 2025-05-07T01:44:43Z
      imageDigest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
      architecture: amd64
    cachedUpdate: null
    incompatible: false
    pinned: true
    store: ostreeContainer
    ostree:
      checksum: fd78346c7935323a1af213718b85ca21b25f69ea91affa5c30c38cb2ff3eebf3
      deploySerial: 0
  rollback:
    image:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
        signature: containerPolicy
      version: '250505'
      timestamp: 2025-05-05T01:46:41Z
      imageDigest: sha256:6c4d19f8ecc21c055c81d0993921399f0cc034ec69ad49bece9c12f5bb1dddf8
      architecture: amd64
    cachedUpdate:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
        signature: containerPolicy
      version: '250507'
      timestamp: 2025-05-07T01:44:43Z
      imageDigest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
      architecture: amd64
    incompatible: false
    pinned: false
    store: ostreeContainer
    ostree:
      checksum: 9af4a6d0f76b6b6d0fe0ca6d8bd87f01ec328c959fe456f755300405d7fd1b02
      deploySerial: 0
  otherDeployments:
  - image:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
      version: '250427'
      timestamp: 2025-04-27T01:44:43Z
      imageDigest: sha256:244bcf3584f5dd9bb424f5dbb0084709c9b68a12299e8242cb4e7fa74e31a7a9
      architecture: amd64
    cachedUpdate:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
      version: '250429'
      timestamp: 2025-04-29T01:45:31Z
      imageDigest: sha256:6f37694f15a64e92f04d8341e0f1ea5d8c67c0fda39f916c8b7740075468a331
      architecture: amd64
    incompatible: false
    pinned: true
    store: ostreeContainer
    ostree:
      checksum: d67eb1fcd1afa31735d278255a94fe9783c5ac5b7b443ae27d5d13a0ef8e0b03
      deploySerial: 0
  - image:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
        signature: containerPolicy
      version: '250425'
      timestamp: 2025-04-25T01:46:32Z
      imageDigest: sha256:b1874fbb5f442657f3cc07a547c54292ca3f24fe828ab4f3132df4c9f23f1e3e
      architecture: amd64
    cachedUpdate:
      image:
        image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        transport: registry
        signature: containerPolicy
      version: '250427'
      timestamp: 2025-04-27T01:44:43Z
      imageDigest: sha256:244bcf3584f5dd9bb424f5dbb0084709c9b68a12299e8242cb4e7fa74e31a7a9
      architecture: amd64
    incompatible: false
    pinned: true
    store: ostreeContainer
    ostree:
      checksum: cac59f70910b5ef683d1e6589609789d104d206c18089efa14b51619466cfe17
      deploySerial: 1
  rollbackQueued: false
  type: bootcHost
```
