### PR TITLE
Split mount code into separate helper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "bootc-blockdev",
+ "bootc-mount",
  "bootc-sysusers",
  "bootc-tmpfiles",
  "bootc-utils",
@@ -243,6 +244,21 @@ dependencies = [
  "tracing",
  "uuid",
  "xshell",
+]
+
+[[package]]
+name = "bootc-mount"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bootc-utils",
+ "camino",
+ "fn-error-context",
+ "indoc",
+ "libc",
+ "rustix 1.0.3",
+ "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli",
     "system-reinstall-bootc",
     "lib",
+    "mount",
     "ostree-ext",
     "utils",
     "blockdev",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,6 +18,7 @@ anstyle = "1.0.6"
 anyhow = { workspace = true }
 bootc-utils = { path = "../utils" }
 bootc-blockdev = { path = "../blockdev" }
+bootc-mount = { path = "../mount" }
 bootc-tmpfiles = { path = "../tmpfiles" }
 bootc-sysusers = { path = "../sysusers" }
 camino = { workspace = true, features = ["serde1"] }

--- a/lib/src/bootloader.rs
+++ b/lib/src/bootloader.rs
@@ -4,6 +4,7 @@ use fn_error_context::context;
 
 use crate::task::Task;
 use bootc_blockdev::PartitionTable;
+use bootc_mount as mount;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
 pub(crate) const EFI_DIR: &str = "efi";
@@ -33,7 +34,7 @@ pub(crate) fn install_via_bootupd(
 #[context("Installing bootloader using zipl")]
 pub(crate) fn install_via_zipl(device: &PartitionTable, boot_uuid: &str) -> Result<()> {
     // Identify the target boot partition from UUID
-    let fs = crate::mount::inspect_filesystem_by_uuid(boot_uuid)?;
+    let fs = mount::inspect_filesystem_by_uuid(boot_uuid)?;
     let boot_dir = Utf8Path::new(&fs.target);
     let maj_min = fs.maj_min;
 

--- a/lib/src/install/baseline.rs
+++ b/lib/src/install/baseline.rs
@@ -27,10 +27,9 @@ use super::RootSetup;
 use super::State;
 use super::RUN_BOOTC;
 use super::RW_KARG;
-use crate::mount;
-#[cfg(feature = "install-to-disk")]
-use crate::mount::is_mounted_in_pid1_mountns;
 use crate::task::Task;
+#[cfg(feature = "install-to-disk")]
+use bootc_mount::is_mounted_in_pid1_mountns;
 
 // This ensures we end up under 512 to be small-sized.
 pub(crate) const BOOTPN_SIZE_MB: u32 = 510;
@@ -421,7 +420,7 @@ pub(crate) fn install_create_rootfs(
         .chain(bootarg)
         .collect::<Vec<_>>();
 
-    mount::mount(&rootdev, &physical_root_path)?;
+    bootc_mount::mount(&rootdev, &physical_root_path)?;
     let target_rootfs = Dir::open_ambient_dir(&physical_root_path, cap_std::ambient_authority())?;
     crate::lsm::ensure_dir_labeled(&target_rootfs, "", Some("/".into()), 0o755.into(), sepolicy)?;
     let physical_root = Dir::open_ambient_dir(&physical_root_path, cap_std::ambient_authority())?;
@@ -429,7 +428,7 @@ pub(crate) fn install_create_rootfs(
     // Create the underlying mount point directory, which should be labeled
     crate::lsm::ensure_dir_labeled(&target_rootfs, "boot", None, 0o755.into(), sepolicy)?;
     if let Some(bootdev) = bootdev {
-        mount::mount(bootdev.node.as_str(), &bootfs)?;
+        bootc_mount::mount(bootdev.node.as_str(), &bootfs)?;
     }
     // And we want to label the root mount of /boot
     crate::lsm::ensure_dir_labeled(&target_rootfs, "boot", None, 0o755.into(), sepolicy)?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -35,7 +35,6 @@ mod bootloader;
 mod containerenv;
 mod install;
 mod kernel;
-pub(crate) mod mount;
 
 #[cfg(feature = "rhsm")]
 mod rhsm;

--- a/mount/Cargo.toml
+++ b/mount/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+description = "Internal mount code"
+# Should never be published to crates.io
+publish = false
+edition = "2021"
+license = "MIT OR Apache-2.0"
+name = "bootc-mount"
+repository = "https://github.com/containers/bootc"
+version = "0.0.0"
+
+[dependencies]
+anyhow = { workspace = true }
+bootc-utils = { path = "../utils" }
+camino = { workspace = true, features = ["serde1"] }
+fn-error-context = { workspace = true }
+rustix = { workspace = true }
+libc = {workspace = true}
+serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+indoc = "2.0.5"
+
+[lib]
+path = "src/mount.rs"


### PR DESCRIPTION
Prep for using this elsewhere via git dependency, like we're doing now with bootupd for example.