### PR TITLE
Add alongside-cleanup systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,13 @@ install:
 	# Copy dracut and systemd config files
 	cp -Prf baseimage/dracut $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
 	cp -Prf baseimage/systemd $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/systemd
+	# Install fedora-bootc-destructive-cleanup in fedora derivatives 
+	ID=$$(. /usr/lib/os-release && echo $$ID); \
+	ID_LIKE=$$(. /usr/lib/os-release && echo $$ID_LIKE); \
+	if [ "$$ID" = "fedora" ] || [[ "$$ID_LIKE" == *"fedora"* ]]; then \
+	ln -s ../bootc-destructive-cleanup.service $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-destructive-cleanup.service; \
+	install -D -m 0755 -t $(DESTDIR)/$(prefix)/lib/bootc contrib/scripts/fedora-bootc-destructive-cleanup; \
+	fi
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.

--- a/contrib/scripts/fedora-bootc-destructive-cleanup
+++ b/contrib/scripts/fedora-bootc-destructive-cleanup
@@ -1,0 +1,14 @@
+#!/bin/bash
+# An implementation of --cleanup for bootc installs on Fedora derivatives
+
+set -xeuo pipefail
+
+# Remove all RPMs installed in the physical root (i.e. the previous OS)
+mount -o remount,rw /sysroot
+rpm -qa --root=/sysroot --dbpath=/usr/lib/sysimage/rpm | xargs rpm -e --root=/sysroot --dbpath=/usr/lib/sysimage/rpm
+
+# Remove all container images (including the one that was used to install)
+# Note that this does not remove stopped containers, and so some storage
+# may leak. This may change in the future.
+mount --bind -o rw /sysroot/var/lib/containers /var/lib/containers
+podman system prune --all -f

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1154,7 +1154,8 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
             #[cfg(feature = "install-to-disk")]
             InstallOpts::ToDisk(opts) => crate::install::install_to_disk(opts).await,
             InstallOpts::ToFilesystem(opts) => {
-                crate::install::install_to_filesystem(opts, false).await
+                crate::install::install_to_filesystem(opts, false, crate::install::Cleanup::Skip)
+                    .await
             }
             InstallOpts::ToExistingRoot(opts) => {
                 crate::install::install_to_existing_root(opts).await

--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -44,6 +44,9 @@ pub(crate) fn reinstall_command(image: &str, ssh_key_file: &str) -> Command {
         // The image is always pulled first, so let's avoid requiring the credentials to be baked
         // in the image for this check.
         "--skip-fetch-check",
+        // Always enable the systemd service to cleanup the previous install after booting into the
+        // bootc system for the first time
+        "--cleanup",
     ]
     .map(String::from)
     .to_vec();

--- a/systemd/bootc-destructive-cleanup.service
+++ b/systemd/bootc-destructive-cleanup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cleanup previous the installation after an alongside installation
+Documentation=man:bootc(8)
+ConditionPathExists=/sysroot/etc/bootc-destructive-cleanup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/bootc/fedora-bootc-destructive-cleanup
+PrivateMounts=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This will remove all rpms and containers/images from the previous install (found in /sysroot) on reboot after running `install to-existing-root.`

---

WIP: using this PR to test the rpm build