### PR TITLE
reinstall: Pass RUST_LOG env var into bootc install container

### DIFF
--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -32,6 +32,11 @@ pub(crate) fn reinstall_command(image: &str, ssh_key_file: &str) -> Command {
     .map(String::from)
     .to_vec();
 
+    // Pass along RUST_LOG from the host to enable detailed output from the bootc command
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        podman_command_and_args.push(format!("--env=RUST_LOG={rust_log}"));
+    }
+
     let mut bootc_command_and_args = [
         "bootc",
         "install",


### PR DESCRIPTION
This enables `RUST_LOG=trace system-reinstall-bootc <image>` to print trace messages for the bootc install invocation.