### PR TITLE
feat(switch): support tag + digest image reference

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -340,7 +340,9 @@ pub(crate) async fn prepare_for_pull(
     imgref: &ImageReference,
     target_imgref: Option<&OstreeImageReference>,
 ) -> Result<PreparedPullResult> {
-    let ostree_imgref = &OstreeImageReference::from(imgref.clone());
+    let imgref_canonicalized = imgref.clone().canonicalize()?;
+    tracing::debug!("Canonicalized image reference: {imgref_canonicalized:#}");
+    let ostree_imgref = &OstreeImageReference::from(imgref_canonicalized);
     let mut imp = new_importer(repo, ostree_imgref).await?;
     if let Some(target) = target_imgref {
         imp.set_target(target);
@@ -420,7 +422,9 @@ pub(crate) async fn pull_from_prepared(
     })
     .await;
     let import = import?;
-    let ostree_imgref = &OstreeImageReference::from(imgref.clone());
+    let imgref_canonicalized = imgref.clone().canonicalize()?;
+    tracing::debug!("Canonicalized image reference: {imgref_canonicalized:#}");
+    let ostree_imgref = &OstreeImageReference::from(imgref_canonicalized);
     let wrote_imgref = target_imgref.as_ref().unwrap_or(&ostree_imgref);
 
     if let Some(msg) =


### PR DESCRIPTION
Closes #1165

Performs tag-stripping when the image reference contains both 
a tag and digest.  This allows Skopeo to pull the image 
successfully, while still displaying both the tag + digest inside 
`bootc status`.

---

This does still perform unnecessary actions when switching onto the same image selected via digest, and there's an issue to tackle this no-op deployment here - #205

I chose to keep this logic inside bootc itself, rather than pushing it up to ostree_ext since this same logic will likely be required for the upcoming composefs integration. 

Since there's a separate argument for the transport, I am not accounting for the image ref containing the transport. 
e.g. `containers-storage:quay.io/example/someimage:42@sha256:blah`

```
bootc-switch-to-tag-with-digest on  bootc-switch-to-tag-with-digest via 🦀 
❯ sudo ./target/debug/bootc switch ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open@sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
[sudo] password for admin: 
Fetched layers: 0 B in 0 seconds (0 B/s)                                                                                                                                                                            
  Deploying: done (12 seconds)                                                                                                                                                                                      Pruned images: 1 (layers: 0, objsize: 0 bytes)
Queued for next boot: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open@sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
  Version: 250507
  Digest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e

bootc-switch-to-tag-with-digest on  bootc-switch-to-tag-with-digest via 🦀 took 29s 
❯ sudo ./target/debug/bootc status                                                                                                                            
  Staged image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open@sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
        Digest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e (amd64)
       Version: 250507 (2025-05-07T01:44:43Z)

● Booted image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
        Digest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e (amd64)
       Version: 250507 (2025-05-07T01:44:43Z)

  Rollback image: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
          Digest: sha256:6c4d19f8ecc21c055c81d0993921399f0cc034ec69ad49bece9c12f5bb1dddf8 (amd64)
         Version: 250505 (2025-05-05T01:46:41Z)

bootc-switch-to-tag-with-digest on  bootc-switch-to-tag-with-digest via 🦀 
❯ sudo ./target/debug/bootc switch ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open                                                                        
No changes in ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open => sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e
  Deploying: done (12 seconds)                                                                                                                                                                                      Pruned images: 0 (layers: 0, objsize: 211.6 kB)
Queued for next boot: ghcr.io/rsturla/eternal-linux/lumina:42-nvidia-open
  Version: 250507
  Digest: sha256:fa8a2a7212a110caedb3729d70513fbcd518c4ed3f011ff16f4531b3b7a4d60e

```
