### PR TITLE
Release 1.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "anstream",
  "anstyle",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 readme = "README.md"
 repository = "https://github.com/containers/bootc"
-version = "1.1.7"
+version = "1.1.8"
 # In general we try to keep this pinned to what's in the latest RHEL9.
 # However right now, we bumped to 1.82 as that's what composefs-rs uses.
 rust-version = "1.82.0"


### PR DESCRIPTION

## Updates to system-reinstall-bootc
* reinstall: Pass RUST_LOG env var into bootc install container by @ckyrouac in https://github.com/bootc-dev/bootc/pull/1297
* reinstall: Cleaner formatting of podman bootc install message by @ckyrouac in https://github.com/bootc-dev/bootc/pull/1298

## Other changes
* store: Improve logging for filtered content by @cgwalters in https://github.com/bootc-dev/bootc/pull/1274
* test: Use to-existing-root --acknowledge-destructive by @evan-goode in https://github.com/bootc-dev/bootc/pull/1279
* lints: move misplaced docstring for LINT_VAR_RUN by @jeckersb in https://github.com/bootc-dev/bootc/pull/1290
* fsck: Don't run ostree fsck by @cgwalters in https://github.com/bootc-dev/bootc/pull/1287
* Port from once_cell to std by @cgwalters in https://github.com/bootc-dev/bootc/pull/1283
* Split mount code into separate helper crate by @cgwalters in https://github.com/bootc-dev/bootc/pull/1288
* status: Prep work for https://github.com/bootc-dev/bootc/pull/1285 by @cgwalters in https://github.com/bootc-dev/bootc/pull/1291
* Add alongside-cleanup systemd service by @ckyrouac in https://github.com/bootc-dev/bootc/pull/1289
* install: Do a dynamic mount for /var/tmp by @cgwalters in https://github.com/bootc-dev/bootc/pull/1294
* test: update bootc install script to support Fedora CI gating test by @henrywang in https://github.com/bootc-dev/bootc/pull/1282
* store: Add some more debug tracing by @cgwalters in https://github.com/bootc-dev/bootc/pull/1296

## New Contributors
* @evan-goode made their first contribution in https://github.com/bootc-dev/bootc/pull/1279

**Full Changelog**: https://github.com/bootc-dev/bootc/compare/v1.1.7...v1.1.8