### PR TITLE
Dedup sepolicy handling

### DIFF
--- a/lib/src/lsm.rs
+++ b/lib/src/lsm.rs
@@ -169,6 +169,19 @@ pub(crate) fn selinux_ensure_install_or_setenforce() -> Result<Option<SetEnforce
     Ok(g)
 }
 
+/// A thin wrapper for loading a SELinux policy that maps "policy nonexistent" to None.
+pub(crate) fn new_sepolicy_at(fd: impl AsFd) -> Result<Option<ostree::SePolicy>> {
+    let fd = fd.as_fd();
+    let cancellable = gio::Cancellable::NONE;
+    let sepolicy = ostree::SePolicy::new_at(fd.as_raw_fd(), cancellable)?;
+    let r = if sepolicy.csum().is_none() {
+        None
+    } else {
+        Some(sepolicy)
+    };
+    Ok(r)
+}
+
 #[context("Setting SELinux permissive mode")]
 #[allow(dead_code)]
 pub(crate) fn selinux_set_permissive(permissive: bool) -> Result<()> {


### PR DESCRIPTION
For historical reasons the ostree sepolicy API can exist as a no-op even if it didn't find a policy, one has to query `.csum()` or `.name()` to verify it's present.

In our code just map that case to None.

Followup to 99d30dfd556866091c558559810647bdde4e1ee1 to ensure we consistently handle this case.