### PR TITLE
docs: Fix typos and clarify content

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ start by looking at [ADOPTERS.md](ADOPTERS.md).
 
 ## Community discussion
 
-The [Github discussion forum](https://github.com/containers/bootc/discussions) is enabled.
+The [GitHub discussion forum](https://github.com/containers/bootc/discussions) is enabled.
 
 This project is also tightly related to the previously mentioned Fedora/CentOS bootc project,
 and many developers monitor the relevant discussion forums there. In particular there's a
@@ -46,6 +46,7 @@ Are you interested in working on bootc?  Great!  See our [CONTRIBUTING.md](CONTR
 There is also a list of [MAINTAINERS.md](MAINTAINERS.md).
 
 ## Governance
+See [GOVERNANCE.md](GOVERNANCE.md) for project governance details.
 
 ## Badges
 

--- a/docs/src/filesystem.md
+++ b/docs/src/filesystem.md
@@ -1,7 +1,7 @@
 # Filesystem
 
 As noted in other chapters, the bootc project currently
-depends on [ostree project](https://github.com/ostreedev/ostree/)
+depends on the [ostree project](https://github.com/ostreedev/ostree/)
 for storing the base container image. Additionally there is a [containers/storage](https://github.com/containers/storage) instance for [logically bound images](logically-bound-images.md).
 
 However, bootc is intending to be a "fresh, new container-native interface",
@@ -95,7 +95,7 @@ Some other image-based update systems do not have distinct "versions" of `/etc` 
 it may be populated only set up at install time, and untouched thereafter.  But
 that creates "hysteresis" where the state of the system's `/etc` is strongly
 influenced by the initial image version.  This can lead to problems
-where e.g. a change to `/etc/sudoers.conf` (to give on simple example)
+where e.g. a change to `/etc/sudoers` (to give one simple example)
 would require external intervention to apply.
 
 For more on configuration file best practices, see [Building](building/guidance.md).

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -16,9 +16,8 @@ systemd is in use, systemd acts as pid1 as usual - there's no "outer" process.
 
 # Status
 
-At the current time, bootc has not reached 1.0, and it is possible
-that some APIs and CLIs may change.  For more information, see
-the [1.0 milestone](https://github.com/containers/bootc/milestone/1).
+The CLI and API for bootc are now considered stable. Every existing system
+can be upgraded in place seamlessly across any future changes.
 
 However, the core underlying code uses the [ostree](https://github.com/ostreedev/ostree)
 project which has been powering stable operating system updates for


### PR DESCRIPTION
Especially fix the intro and note that bootc's APIs are stable.