### PR TITLE
ostree-ext: tests: Don't call export_container twice

### DIFF
--- a/ostree-ext/tests/it/main.rs
+++ b/ostree-ext/tests/it/main.rs
@@ -1331,9 +1331,7 @@ async fn test_non_ostree() -> Result<()> {
         return Ok(());
     }
     let fixture = NonOstreeFixture::new_base()?;
-    let src_digest = fixture.export_container().await?.1;
-
-    let imgref = fixture.export_container().await.unwrap().0;
+    let (imgref, src_digest) = fixture.export_container().await.unwrap();
     let imp = fixture.must_import(&imgref).await?;
     if imp.manifest_digest != src_digest {
         let src_manifest: oci_image::ImageManifest = {


### PR DESCRIPTION
Just something weird I noticed when looking at #1328

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
