### PR TITLE
Switch to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 6
+  groups:
+    minor:
+      update-types:
+        - minor
+        - patch

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>platform-engineering-org/.github"
-  ]
-}


### PR DESCRIPTION
Our renovate instance is maintained by a distinct entity, and seems to have been having trouble making updates lately.

I looked at doing an integration via GHA, but it requires a custom token which is a bit awkward.

Let's use the one builtin to GH for now.