### PR TITLE
ostree-ext: make OCI history reproducible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ name = "bootc-utils"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "rustix 1.0.3",
  "serde",
  "serde_json",

--- a/lib/src/install.rs
+++ b/lib/src/install.rs
@@ -535,7 +535,7 @@ impl InstallAleph {
                 l.get(oci_spec::image::ANNOTATION_CREATED)
                     .map(|s| s.as_str())
             })
-            .and_then(crate::status::try_deserialize_timestamp);
+            .and_then(bootc_utils::try_deserialize_timestamp);
         let r = InstallAleph {
             image: src_imageref.imgref.name.clone(),
             version: imgstate.version().as_ref().map(|s| s.to_string()),

--- a/lib/src/status.rs
+++ b/lib/src/status.rs
@@ -102,16 +102,6 @@ pub(crate) struct Deployments {
     pub(crate) other: VecDeque<ostree::Deployment>,
 }
 
-pub(crate) fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
-        Ok(t) => Some(t.into()),
-        Err(e) => {
-            tracing::warn!("Invalid timestamp in image: {:#}", e);
-            None
-        }
-    }
-}
-
 pub(crate) fn labels_of_config(
     config: &oci_spec::image::ImageConfiguration,
 ) -> Option<&std::collections::HashMap<String, String>> {

--- a/lib/src/store/ostree_container.rs
+++ b/lib/src/store/ostree_container.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use ostree_ext::container as ostree_container;
 use ostree_ext::oci_spec;
@@ -52,7 +52,7 @@ fn create_imagestatus(
                 .map(|s| s.as_str())
         })
         .or_else(|| config.created().as_deref())
-        .and_then(try_deserialize_timestamp);
+        .and_then(bootc_utils::try_deserialize_timestamp);
 
     let version = ostree_container::version_for_config(config).map(ToOwned::to_owned);
     let architecture = config.architecture().to_string();
@@ -69,14 +69,4 @@ fn labels_of_config(
     config: &oci_spec::image::ImageConfiguration,
 ) -> Option<&std::collections::HashMap<String, String>> {
     config.config().as_ref().and_then(|c| c.labels().as_ref())
-}
-
-fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
-        Ok(t) => Some(t.into()),
-        Err(e) => {
-            tracing::warn!("Invalid timestamp in image: {:#}", e);
-            None
-        }
-    }
 }

--- a/ostree-ext/src/container/store.rs
+++ b/ostree-ext/src/container/store.rs
@@ -1490,12 +1490,22 @@ pub(crate) fn export_to_oci(
             .get(i)
             .and_then(|h| h.comment().as_deref())
             .unwrap_or_default();
-        dest_oci.push_layer(
+
+        let previous_created = srcinfo
+            .configuration
+            .history()
+            .get(i)
+            .and_then(|h| h.created().as_deref())
+            .and_then(bootc_utils::try_deserialize_timestamp)
+            .unwrap_or_default();
+
+        dest_oci.push_layer_full(
             &mut new_manifest,
             &mut new_config,
             layer,
-            previous_description,
             previous_annotations,
+            previous_description,
+            previous_created,
         )
     }
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/bootc-dev/bootc"
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true, features = ["std"] }
 rustix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -8,5 +8,7 @@ mod path;
 pub use path::*;
 mod iterators;
 pub use iterators::*;
+mod timestamp;
+pub use timestamp::*;
 mod tracing_util;
 pub use tracing_util::*;

--- a/utils/src/timestamp.rs
+++ b/utils/src/timestamp.rs
@@ -1,0 +1,13 @@
+use anyhow::Context;
+use chrono;
+
+/// Try to parse an RFC 3339, warn on error.
+pub fn try_deserialize_timestamp(t: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    match chrono::DateTime::parse_from_rfc3339(t).context("Parsing timestamp") {
+        Ok(t) => Some(t.into()),
+        Err(e) => {
+            tracing::warn!("Invalid timestamp in image: {:#}", e);
+            None
+        }
+    }
+}


### PR DESCRIPTION
OciDir push_layer() calls push_layer_full() with
created = chrono::offset::Utc::now()

This should fix https://github.com/coreos/rpm-ostree/issues/5406