### PR TITLE
reinstall: Only pull the image if it's not already present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,8 @@ jobs:
           sudo mkdir -p /run/sshd
 
           sudo install -m 0755 target/release/system-reinstall-bootc /usr/bin/system-reinstall-bootc
-          sudo podman pull quay.io/fedora/fedora-bootc:42
-          sudo bootc-integration-tests system-reinstall quay.io/fedora/fedora-bootc:42 --test-threads=1
+          # These tests may mutate the system live so we can't run in parallel
+          sudo bootc-integration-tests system-reinstall localhost/bootc --test-threads=1
 
           # And the fsverity case
           sudo podman run --privileged --pid=host localhost/bootc-fsverity bootc install to-existing-root --stateroot=other \

--- a/system-reinstall-bootc/src/main.rs
+++ b/system-reinstall-bootc/src/main.rs
@@ -25,10 +25,7 @@ fn run() -> Result<()> {
     podman::ensure_podman_installed()?;
 
     //pull image early so it can be inspected, e.g. to check for cloud-init
-    let mut pull_image_command = podman::pull_image_command(&config.bootc_image);
-    pull_image_command
-        .run_with_cmd_context()
-        .context(format!("pulling image {}", &config.bootc_image))?;
+    podman::pull_if_not_present(&config.bootc_image)?;
 
     println!();
 

--- a/system-reinstall-bootc/src/podman.rs
+++ b/system-reinstall-bootc/src/podman.rs
@@ -96,10 +96,33 @@ pub(crate) fn reinstall_command(image: &str, ssh_key_file: &str) -> Result<Comma
     Ok(command)
 }
 
-pub(crate) fn pull_image_command(image: &str) -> Command {
+fn pull_image_command(image: &str) -> Command {
     let mut command = Command::new("podman");
     command.args(["pull", image]);
     command
+}
+
+fn image_exists_command(image: &str) -> Command {
+    let mut command = Command::new("podman");
+    command.args(["image", "exists", image]);
+    command
+}
+
+pub(crate) fn pull_if_not_present(image: &str) -> Result<()> {
+    let result = image_exists_command(image).status()?;
+
+    if result.success() {
+        println!("Image {} is already present locally, skipping pull.", image);
+        return Ok(());
+    } else {
+        println!("Image {} is not present locally, pulling it now.", image);
+        println!();
+        pull_image_command(image)
+            .run_with_cmd_context()
+            .context(format!("pulling image {}", image))?;
+    }
+
+    Ok(())
 }
 
 /// Path to the podman installation script. Can be influenced by the build


### PR DESCRIPTION
This enables using a local image with system-reinstall-bootc. A couple drive by cleanups to the integration tests are included.