### PR TITLE
ostree-ext: specify zeroed patch version for ostree

### DIFF
--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.15.3"
 # semver here you must also bump our semver.
 containers-image-proxy = "0.7.0"
 # We re-export this library too.
-ostree = { features = ["v2025_2"], version = "0.20" }
+ostree = { features = ["v2025_2"], version = "0.20.0" }
 
 # Private dependencies
 anyhow = { workspace = true }


### PR DESCRIPTION
This was changed previously in #1328, this reverts to the old format.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
