### PR TITLE
Two minor patches

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -121,7 +121,8 @@ cat >%{?buildroot}/%{system_reinstall_bootc_install_podman_path} <<EOF
 exec dnf -y install podman
 EOF
 chmod +x %{?buildroot}/%{system_reinstall_bootc_install_podman_path}
-# generate doc file list excluding directories
+# generate doc file list excluding directories; workaround for
+# https://github.com/coreos/rpm-ostree/issues/5420
 touch %{?buildroot}/%{_docdir}/bootc/baseimage/base/sysroot/.keepdir
 find %{?buildroot}/%{_docdir} ! -type d -printf '%{_docdir}/%%P\n' > bootcdoclist.txt
 

--- a/ostree-ext/src/tar/export.rs
+++ b/ostree-ext/src/tar/export.rs
@@ -640,6 +640,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
     fn write_parents_of(
         &mut self,
         path: &Utf8Path,
+        root: &gio::File,
         cache: &mut HashSet<Utf8PathBuf>,
     ) -> Result<()> {
         let Some(parent) = path.parent() else {
@@ -654,15 +655,11 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             return Ok(());
         }
 
-        self.write_parents_of(parent, cache)?;
+        self.write_parents_of(parent, root, cache)?;
 
         let inserted = cache.insert(parent.to_owned());
         debug_assert!(inserted);
 
-        let root = self
-            .repo
-            .read_commit(&self.commit_checksum, gio::Cancellable::NONE)?
-            .0;
         let parent_file = root.resolve_relative_path(unmap_path(parent).as_ref());
         let queryattrs = "unix::*";
         let queryflags = gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS;
@@ -733,13 +730,17 @@ fn write_chunk<W: std::io::Write>(
     create_parent_dirs: bool,
 ) -> Result<()> {
     let mut cache = std::collections::HashSet::new();
+    let root = writer
+        .repo
+        .read_commit(&writer.commit_checksum, gio::Cancellable::NONE)?
+        .0;
     for (checksum, (_size, paths)) in chunk.into_iter() {
         let (objpath, h) = writer.append_content(checksum.borrow())?;
         for path in paths.iter() {
             let path = path_for_tar_v1(path);
             let h = h.clone();
             if create_parent_dirs {
-                writer.write_parents_of(&path, &mut cache)?;
+                writer.write_parents_of(&path, &root, &mut cache)?;
             }
             writer.append_content_hardlink(&objpath, h, path)?;
         }


### PR DESCRIPTION
build-sys: Add a link to rpm-ostree issue

Just to meke it easier to find.

Signed-off-by: Colin Walters <walters@verbum.org>

---

tar/export: Only load root once

Minor optimization for previous commit.

---
