### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/docs/src/building/guidance.md
+++ b/docs/src/building/guidance.md
@@ -135,7 +135,7 @@ is generic support for `/etc`.
 
 Some software supports generic configuration both `/usr` and `/etc` - systemd,
 among others.  Because bootc supports *derivation* (the way OCI
-containers work) - it is supported and encourged to put configuration
+containers work) - it is supported and encouraged to put configuration
 files in `/usr` (instead of `/etc`) where possible, because then
 the state is consistently immutable.
 

--- a/docs/src/building/users-and-groups.md
+++ b/docs/src/building/users-and-groups.md
@@ -230,7 +230,7 @@ However in contrast, the cockpit project allocates
 [a floating cockpit-ws user](https://gitlab.com/redhat/centos-stream/rpms/cockpit/-/blob/1909236ad28c7d93238b8b3b806ecf9c4feb7e46/cockpit.spec#L506).
 
 This means that each container image build (without additional work, unlike the
-example at the begining of this section),may (due to RPM installation 
+example at the beginning of this section),may (due to RPM installation 
 ordering or other reasons) result in the uid changing.
 
 This can be a problem if that user maintains persistent state.


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation files guidance.md and users-and-groups.md. Specifically, it fixes the spelling of "encouraged" and "beginning" to improve clarity and professionalism in the documentation. No functional changes are introduced.