### PR TITLE
Create /run/reboot-required by default

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -737,6 +737,13 @@ pub(crate) async fn stage(
     })
     .await;
 
+    // Unconditionally create or update /run/reboot-required to signal a reboot is needed.
+    // This is monitored by kured (Kubernetes Reboot Daemon).
+    let run_dir = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
+    run_dir
+        .atomic_write("reboot-required", b"")
+        .context("Creating /run/reboot-required")?;
+
     Ok(())
 }
 

--- a/tmt/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tmt/tests/booted/test-image-pushpull-upgrade.nu
@@ -65,6 +65,10 @@ RUN echo test content > /usr/share/blah.txt
     let progress = open --raw $progress_json | from json -o
     sanity_check_switch_progress_json $progress
 
+    # Check that /run/reboot-required exists and is a zero-byte file
+    let rr_meta = (ls /run/reboot-required | first)
+    assert equal $rr_meta.size 0b
+
     # Also test that the mtime changes on modification
     let new_root_mtime = ls -Dl /ostree/bootc | get modified
     assert ($new_root_mtime > $orig_root_mtime)


### PR DESCRIPTION
When staging a new deployment, create /run/reboot-required to signal that a reboot is needed. This file is monitored by kured (Kubernetes Reboot Daemon) and other tools to detect when a system needs to be rebooted.

This makes it easier to integrate bootc with kured and similar tools without requiring manual configuration or bridging.

Fixes: [#1353](https://github.com/bootc-dev/bootc/issues/1353)