### PR TITLE
deploy: short-circuit pull if digest pullspec already exists

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 use std::io::{BufRead, Write};
+use std::str::FromStr;
 
 use anyhow::Ok;
 use anyhow::{anyhow, Context, Result};
@@ -15,6 +16,7 @@ use ostree::{gio, glib};
 use ostree_container::OstreeImageReference;
 use ostree_ext::container as ostree_container;
 use ostree_ext::container::store::{ImageImporter, ImportProgress, PrepareResult, PreparedImport};
+use ostree_ext::oci_spec::distribution::Reference as OciReference;
 use ostree_ext::oci_spec::image::{Descriptor, Digest};
 use ostree_ext::ostree::Deployment;
 use ostree_ext::ostree::{self, Sysroot};
@@ -343,6 +345,20 @@ pub(crate) async fn prepare_for_pull(
     let imgref_canonicalized = imgref.clone().canonicalize()?;
     tracing::debug!("Canonicalized image reference: {imgref_canonicalized:#}");
     let ostree_imgref = &OstreeImageReference::from(imgref_canonicalized);
+
+    let maybe_oci_ref = ostree_imgref.imgref.name.parse::<OciReference>().ok();
+    if let Some(digest) = maybe_oci_ref.as_ref().and_then(|oci_ref| oci_ref.digest()) {
+        // This is a digested pull. If that digested image already exists in
+        // the store, we can short-circuit a lot here and e.g. not spawn skopeo
+        // at all.
+        if let Some(c) = ostree_container::store::query_image(repo, &ostree_imgref.imgref)? {
+            let digest = Digest::from_str(digest)?;
+            assert_eq!(digest, c.manifest_digest);
+            println!("Digest-based pullspec {imgref:#} already present");
+            return Ok(PreparedPullResult::AlreadyPresent(Box::new((*c).into())));
+        }
+    }
+
     let mut imp = new_importer(repo, ostree_imgref).await?;
     if let Some(target) = target_imgref {
         imp.set_target(target);


### PR DESCRIPTION
If we're pulling by digest and the pullspec already exists, then there's no need to reach out to the registry or even spawn skopeo.

Detect this case and exit early in the pull code.

This allows RHCOS to conform better to the PinnedImageSet API[1], where the expectation is that once an image is pulled, the registry will not be contacted again. In a future with unified storage, the MCO's pre-pull would work just the same for the RHCOS image as any other.

Framing this more generally: this patch allows one to pre-pull an image into the store, and making the later deployment operation be fully offline. E.g. this could be used to implement a `bootc switch --download-only` option.

[1] https://github.com/openshift/enhancements/blob/26ce3cd8a0c7ce650e73bc5393a3605022cb6847/enhancements/machine-config/pin-and-pre-load-images.md