### PR TITLE
Fix typos in code comments

### DIFF
--- a/lib/src/deploy.rs
+++ b/lib/src/deploy.rs
@@ -554,7 +554,7 @@ async fn deploy(
     };
     // Clone all the things to move to worker thread
     let sysroot_clone = sysroot.sysroot.clone();
-    // ostree::Deployment is incorrently !Send 😢 so convert it to an integer
+    // ostree::Deployment is incorrectly !Send 😢 so convert it to an integer
     let merge_deployment = merge_deployment.map(|d| d.index() as usize);
     let stateroot = stateroot.to_string();
     let ostree_commit = image.ostree_commit.to_string();

--- a/ostree-ext/src/container/store.rs
+++ b/ostree-ext/src/container/store.rs
@@ -3,7 +3,7 @@
 //! # Extension of encapsulation support
 //!
 //! This code supports ingesting arbitrary layered container images from an ostree-exported
-//! base.  See [`encapsulate`][`super::encapsulate()`] for more information on encaspulation of images.
+//! base.  See [`encapsulate`][`super::encapsulate()`] for more information on encapsulation of images.
 
 use super::*;
 use crate::chunking::{self, Chunk};


### PR DESCRIPTION


### Description
Fixed spelling mistakes in documentation comments:
- `incorrently` → `incorrectly` in `lib/src/deploy.rs`
- `encapsulation` casing fix in `ostree-ext/src/container/store.rs`
