### PR TITLE
Rework utils and blockdev crates as -internals in prep for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,8 +177,8 @@ version = "0.0.0"
 dependencies = [
  "anstream",
  "anyhow",
+ "bootc-internal-utils",
  "bootc-lib",
- "bootc-utils",
  "log",
  "owo-colors",
  "tokio",
@@ -186,11 +186,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "bootc-blockdev"
+name = "bootc-internal-blockdev"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "fn-error-context",
  "indoc",
@@ -201,17 +201,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bootc-internal-utils"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rustix 1.0.3",
+ "serde",
+ "serde_json",
+ "shlex",
+ "similar-asserts",
+ "static_assertions",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "bootc-lib"
 version = "1.4.0"
 dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
- "bootc-blockdev",
+ "bootc-internal-blockdev",
+ "bootc-internal-utils",
  "bootc-mount",
  "bootc-sysusers",
  "bootc-tmpfiles",
- "bootc-utils",
  "camino",
  "canon-json",
  "cap-std-ext",
@@ -254,7 +272,7 @@ name = "bootc-mount"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "fn-error-context",
  "indoc",
@@ -269,7 +287,7 @@ name = "bootc-sysusers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "cap-std-ext",
  "fn-error-context",
@@ -287,7 +305,7 @@ name = "bootc-tmpfiles"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "cap-std-ext",
  "fn-error-context",
@@ -297,24 +315,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "uzers",
-]
-
-[[package]]
-name = "bootc-utils"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "chrono",
- "rustix 1.0.3",
- "serde",
- "serde_json",
- "shlex",
- "similar-asserts",
- "static_assertions",
- "tempfile",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1794,7 +1794,7 @@ name = "ostree-ext"
 version = "0.15.3"
 dependencies = [
  "anyhow",
- "bootc-utils",
+ "bootc-internal-utils",
  "camino",
  "canon-json",
  "cap-std-ext",
@@ -2498,8 +2498,8 @@ name = "system-reinstall-bootc"
 version = "0.1.9"
 dependencies = [
  "anyhow",
+ "bootc-internal-utils",
  "bootc-mount",
- "bootc-utils",
  "clap",
  "crossterm 0.29.0",
  "dialoguer",

--- a/blockdev/Cargo.toml
+++ b/blockdev/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
-description = "Internal blockdev code"
-# Should never be published to crates.io
-publish = false
+description = "Internal implementation component of bootc; do not use"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-name = "bootc-blockdev"
+name = "bootc-internal-blockdev"
 repository = "https://github.com/bootc-dev/bootc"
 version = "0.0.0"
 
 [dependencies]
 anyhow = { workspace = true }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 camino = { workspace = true, features = ["serde1"] }
 fn-error-context = { workspace = true }
 regex = "1.10.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,7 +18,7 @@ platforms = ["*-unknown-linux-gnu"]
 anstream = { workspace = true }
 anyhow = { workspace = true }
 bootc-lib = { version = "1.0", path = "../lib" }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 tokio = { workspace = true, features = ["macros"] }
 log = "0.4.21"
 owo-colors = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,8 +18,8 @@ include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]
 anstream = "0.6.13"
 anstyle = "1.0.6"
 anyhow = { workspace = true }
-bootc-utils = { path = "../utils" }
-bootc-blockdev = { path = "../blockdev" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
+bootc-blockdev = { package = "bootc-internal-blockdev", path = "../blockdev", version = "0.0.0" }
 bootc-mount = { path = "../mount" }
 bootc-tmpfiles = { path = "../tmpfiles" }
 bootc-sysusers = { path = "../sysusers" }

--- a/mount/Cargo.toml
+++ b/mount/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = { workspace = true }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 camino = { workspace = true, features = ["serde1"] }
 fn-error-context = { workspace = true }
 rustix = { workspace = true }

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -15,7 +15,7 @@ ostree = { features = ["v2025_2"], version = "0.20" }
 
 # Private dependencies
 anyhow = { workspace = true }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 camino = { workspace = true, features = ["serde1"] }
 composefs = { git = "https://github.com/containers/composefs-rs", rev = "821eeae93e48f1ee381c49b8cd4d22fda92d27a2" }
 chrono = { workspace = true }

--- a/system-reinstall-bootc/Cargo.toml
+++ b/system-reinstall-bootc/Cargo.toml
@@ -17,7 +17,7 @@ platforms = ["*-unknown-linux-gnu"]
 [dependencies]
 anyhow = { workspace = true }
 bootc-mount = { path = "../mount" }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 clap = { workspace = true, features = ["derive"] }
 crossterm = "0.29.0"
 dialoguer = "0.11.0"

--- a/sysusers/Cargo.toml
+++ b/sysusers/Cargo.toml
@@ -13,7 +13,7 @@ cap-std-ext = { version = "4", features = ["fs_utf8"] }
 hex = "0.4"
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 rustix = { workspace = true }
 uzers = "0.12"
 

--- a/tmpfiles/Cargo.toml
+++ b/tmpfiles/Cargo.toml
@@ -11,7 +11,7 @@ fn-error-context = { workspace = true }
 cap-std-ext = { version = "4" }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-bootc-utils = { path = "../utils" }
+bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 rustix = { workspace = true }
 uzers = "0.12"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "bootc-utils"
-publish = false
+name = "bootc-internal-utils"
+description = "Internal implementation component of bootc; do not use"
 version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
See https://github.com/coreos/bootupd/pull/963

Basically I just want a way to keep these in sync with bootupd; we're not attempting to make a truly public library.