### PR TITLE
chunking: Support exclusive chunks defined via xattrs

### DIFF
--- a/ostree-ext/src/cli.rs
+++ b/ostree-ext/src/cli.rs
@@ -766,7 +766,7 @@ async fn container_export(
     container_config: Option<Utf8PathBuf>,
     cmd: Option<Vec<String>>,
     compression_fast: bool,
-    contentmeta: Option<Utf8PathBuf>,
+    package_contentmeta: Option<Utf8PathBuf>,
 ) -> Result<()> {
     let container_config = if let Some(container_config) = container_config {
         serde_json::from_reader(File::open(container_config).map(BufReader::new)?)?
@@ -777,7 +777,7 @@ async fn container_export(
     let mut contentmeta_data = None;
     let mut created = None;
     let mut labels = labels.clone();
-    if let Some(contentmeta) = contentmeta {
+    if let Some(contentmeta) = package_contentmeta {
         let buf = File::open(contentmeta).map(BufReader::new);
         let raw: RawMeta = serde_json::from_reader(buf?)?;
 
@@ -842,7 +842,7 @@ async fn container_export(
         container_config,
         authfile,
         skip_compression: compression_fast, // TODO rename this in the struct at the next semver break
-        contentmeta: contentmeta_data.as_ref(),
+        package_contentmeta: contentmeta_data.as_ref(),
         max_layers,
         created,
         ..Default::default()

--- a/ostree-ext/src/container/encapsulate.rs
+++ b/ostree-ext/src/container/encapsulate.rs
@@ -239,7 +239,7 @@ fn build_oci(
     let mut manifest = writer.new_empty_manifest()?.build().unwrap();
 
     let chunking = opts
-        .contentmeta
+        .package_contentmeta
         .as_ref()
         .map(|meta| {
             crate::chunking::Chunking::from_mapping(
@@ -248,6 +248,7 @@ fn build_oci(
                 meta,
                 &opts.max_layers,
                 opts.prior_build,
+                opts.specific_contentmeta,
             )
         })
         .transpose()?;
@@ -427,7 +428,9 @@ pub struct ExportOpts<'m, 'o> {
     pub prior_build: Option<&'m oci_image::ImageManifest>,
     /// Metadata mapping between objects and their owning component/package;
     /// used to optimize packing.
-    pub contentmeta: Option<&'o ObjectMetaSized>,
+    pub package_contentmeta: Option<&'o ObjectMetaSized>,
+    /// Metadata for exclusive components that should have their own layers.
+    pub specific_contentmeta: Option<&'o ObjectMetaSized>,
     /// Sets the created tag in the image manifest.
     pub created: Option<String>,
     /// Whether to explicitly create all parent directories in the tar layers.

--- a/ostree-ext/src/fixture.rs
+++ b/ostree-ext/src/fixture.rs
@@ -909,7 +909,7 @@ impl Fixture {
             .context("Computing sizes")?;
         let opts = ExportOpts {
             max_layers: std::num::NonZeroU32::new(PKGS_V0_LEN as u32),
-            contentmeta: Some(&contentmeta),
+            package_contentmeta: Some(&contentmeta),
             ..Default::default()
         };
         let digest = crate::container::encapsulate(

--- a/ostree-ext/src/objectsource.rs
+++ b/ostree-ext/src/objectsource.rs
@@ -37,7 +37,7 @@ mod rcstr_serialize {
 pub type ContentID = Rc<str>;
 
 /// Metadata about a component/package.
-#[derive(Debug, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, Deserialize, Serialize)]
 pub struct ObjectSourceMeta {
     /// Unique identifier, does not need to be human readable, but can be.
     #[serde(with = "rcstr_serialize")]

--- a/ostree-ext/tests/it/main.rs
+++ b/ostree-ext/tests/it/main.rs
@@ -534,7 +534,7 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
     opts.copy_meta_keys = vec!["buildsys.checksum".to_string()];
     opts.copy_meta_opt_keys = vec!["nosuchvalue".to_string()];
     opts.max_layers = std::num::NonZeroU32::new(PKGS_V0_LEN as u32);
-    opts.contentmeta = contentmeta.as_ref();
+    opts.package_contentmeta = contentmeta.as_ref();
     opts.container_config = Some(container_config);
     let digest = ostree_ext::container::encapsulate(
         fixture.srcrepo(),


### PR DESCRIPTION
This adds a new "specific_components" parameter to process_mapping to enable mapping individual files to specific layers. This will be used by the rechunker in rpm-ostree.

Related to: https://github.com/coreos/rpm-ostree/pull/5431