### PR TITLE
blockdev: Fix loopback device resource leak on signal interruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,13 @@ dependencies = [
  "camino",
  "fn-error-context",
  "indoc",
+ "libc",
  "regex",
+ "rustix 1.0.3",
  "serde",
  "serde_json",
+ "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/blockdev/Cargo.toml
+++ b/crates/blockdev/Cargo.toml
@@ -11,9 +11,13 @@ anyhow = { workspace = true }
 bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 camino = { workspace = true, features = ["serde1"] }
 fn-error-context = { workspace = true }
+libc = { workspace = true }
 regex = "1.10.4"
+rustix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -464,6 +464,12 @@ pub(crate) enum InternalsOpts {
         #[clap(allow_hyphen_values = true)]
         args: Vec<OsString>,
     },
+    /// Loopback device cleanup helper (internal use only)
+    LoopbackCleanupHelper {
+        /// Device path to clean up
+        #[clap(long)]
+        device: String,
+    },
     /// Invoked from ostree-ext to complete an installation.
     BootcInstallCompletion {
         /// Path to the sysroot
@@ -1260,6 +1266,9 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
             InternalsOpts::BootcInstallCompletion { sysroot, stateroot } => {
                 let rootfs = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
                 crate::install::completion::run_from_ostree(rootfs, &sysroot, &stateroot).await
+            }
+            InternalsOpts::LoopbackCleanupHelper { device } => {
+                crate::blockdev::run_loopback_cleanup_helper(&device).await
             }
             #[cfg(feature = "rhsm")]
             InternalsOpts::PublishRhsmFacts => crate::rhsm::publish_facts(&root).await,

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -38,3 +38,6 @@ mod kernel;
 
 #[cfg(feature = "rhsm")]
 mod rhsm;
+
+// Re-export blockdev crate for internal use
+pub(crate) use bootc_blockdev as blockdev;


### PR DESCRIPTION
This commit implements issue #799 by creating a signal-safe cleanup helper for loopback devices to prevent resource leaks when bootc install --via-loopback is interrupted by signals like SIGINT (Ctrl-C).

The solution uses an 'out-of-process drop' helper that:
- Forks a cleanup helper process when creating a loopback device
- Uses PR_SET_PDEATHSIG to detect when the parent process dies
- Masks most signals to avoid being killed accidentally
- Automatically cleans up leaked loopback devices if the parent dies
- Gracefully terminates when the parent performs normal cleanup

This prevents the common issue where interrupting bootc install --via-loopback with Ctrl-C would leave /dev/loopN devices allocated on the system.

Fixes: https://github.com/bootc-dev/bootc/issues/799