### PR TITLE
chore: switch bootc-fetch-apply-updates.service to non-aliased command

### DIFF
--- a/systemd/bootc-fetch-apply-updates.service
+++ b/systemd/bootc-fetch-apply-updates.service
@@ -5,4 +5,4 @@ ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/bootc update --apply --quiet
+ExecStart=/usr/bin/bootc upgrade --apply --quiet


### PR DESCRIPTION
#1404 

This just makes it a bit easier to understand what the systemd unit is doing.  Right now, it's calling an aliased command, making it a bit tricky to understand how it works.

I don't think all aliases need to be in `--help`, but do believe we should try and not use undocumented aliases in service units.