### PR TITLE
Bump composefs-rs and use-libc for rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=59299eb8de6c22410f32213cc57901a7ddd3c134#59299eb8de6c22410f32213cc57901a7ddd3c134"
+source = "git+https://github.com/containers/composefs-rs?rev=d5455222f282200913902f29c66d5f625ca5661f#d5455222f282200913902f29c66d5f625ca5661f"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ fn-error-context = "0.2.1"
 libc = "0.2.154"
 openssl = "0.10.72"
 owo-colors = { version = "4" }
-rustix = { "version" = "1", features = ["thread", "net", "fs", "system", "process", "mount"] }
+# For the same rationale as https://github.com/coreos/rpm-ostree/commit/27f3f4b77a15f6026f7e1da260408d42ccb657b3
+rustix = { "version" = "1", features = ["use-libc", "thread", "net", "fs", "system", "process", "mount"] }
 serde = "1.0.199"
 serde_json = "1.0.116"
 similar-asserts = "1.5.0"

--- a/ostree-ext/Cargo.toml
+++ b/ostree-ext/Cargo.toml
@@ -17,7 +17,7 @@ ostree = { features = ["v2025_2"], version = "0.20" }
 anyhow = { workspace = true }
 bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 camino = { workspace = true, features = ["serde1"] }
-composefs = { git = "https://github.com/containers/composefs-rs", rev = "59299eb8de6c22410f32213cc57901a7ddd3c134", features = ["rhel9"] }
+composefs = { git = "https://github.com/containers/composefs-rs", rev = "d5455222f282200913902f29c66d5f625ca5661f", features = ["rhel9"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive","cargo"] }
 clap_mangen = { workspace = true, optional = true }


### PR DESCRIPTION
- Bump composefs so we build on s390x and ppc64le
- use-libc for rustix so we will always work the same across every platform