### PR TITLE
build: Add actions to automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    if: |
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'release'))
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract version
+        id: extract_version
+        run: |
+          # Extract version from crates/lib/Cargo.toml
+          VERSION=$(grep '^version' crates/lib/Cargo.toml | sed 's/version = "//;s/"//')
+          
+          # Validate version format
+          if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+            echo "Error: Invalid version format in Cargo.toml: $VERSION"
+            exit 1
+          fi
+          
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=v$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Install deps
+        run: ./ci/installdeps.sh
+      
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      
+      - name: Import GPG key
+        if: github.event_name != 'push'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      
+      - name: Create and push tag
+        if: github.event_name != 'push'
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          TAG_NAME="v$VERSION"
+          
+          # Check if tag already exists
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists"
+            exit 0
+          fi
+          
+          # Create signed annotated tag
+          git tag -s -m "Release $VERSION" "$TAG_NAME"
+          
+          # Push the tag
+          git push origin "$TAG_NAME"
+          
+          echo "Successfully created and pushed tag $TAG_NAME"
+          
+          # Switch to the tagged commit for building
+          git checkout "$TAG_NAME"
+      
+      - name: Install vendor tool
+        run: cargo install cargo-vendor-filterer
+      
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "release"
+      
+      - name: Run cargo xtask package
+        run: cargo xtask package
+      
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version.outputs.TAG_NAME }}
+          release_name: Release ${{ steps.extract_version.outputs.TAG_NAME }}
+          draft: true
+          prerelease: false
+          body: |
+            ## bootc ${{ steps.extract_version.outputs.version }}
+            
+            ### Changes
+            
+            Auto-generated release notes will be populated here.
+            
+            ### Assets
+            
+            - `bootc-${{ steps.extract_version.outputs.version }}-vendor.tar.zstd` - Vendored dependencies archive
+            - `bootc-${{ steps.extract_version.outputs.version }}.tar.zstd` - Source archive
+      
+      - name: Upload vendor archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/bootc-${{ steps.extract_version.outputs.version }}-vendor.tar.zstd
+          asset_name: bootc-${{ steps.extract_version.outputs.version }}-vendor.tar.zstd
+          asset_content_type: application/zstd
+      
+      - name: Upload source archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/bootc-${{ steps.extract_version.outputs.version }}.tar.zstd
+          asset_name: bootc-${{ steps.extract_version.outputs.version }}.tar.zstd
+          asset_content_type: application/zstd

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,0 +1,163 @@
+name: Create Release PR
+
+on:
+  schedule:
+    # Run every 3 weeks on Monday at 8:00 AM UTC
+    # Note: GitHub Actions doesn't support "every 3 weeks" directly,
+    # so we use a workaround by running weekly and checking if it's been 3 weeks
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.5.1). Leave empty to auto-increment.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Install deps
+        run: ./ci/installdeps.sh
+      
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      
+      - name: Check if it's time for a release
+        id: check_schedule
+        run: |
+          # For manual workflow dispatch, always proceed
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # For scheduled runs, check if it's been 3 weeks since the last release
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LAST_TAG_DATE=$(git log -1 --format=%ct "$LAST_TAG" 2>/dev/null || echo "0")
+          CURRENT_DATE=$(date +%s)
+          DAYS_SINCE_RELEASE=$(( (CURRENT_DATE - LAST_TAG_DATE) / 86400 ))
+          
+          echo "Days since last release: $DAYS_SINCE_RELEASE"
+          
+          # Release if it's been at least 21 days (3 weeks)
+          if [ $DAYS_SINCE_RELEASE -ge 21 ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Determine next version
+        if: steps.check_schedule.outputs.should_release == 'true'
+        id: next_version
+        run: |
+          # If version is provided via workflow dispatch, validate and use it
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+            # Validate version format strictly
+            if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+              echo "Error: Invalid version format. Expected X.Y.Z (e.g., 1.5.1)"
+              exit 1
+            fi
+            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Use make command to get next minor version
+          NEW_VERSION=$(make next-minor-version)
+          
+          echo "New version: $NEW_VERSION"
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Import GPG key
+        if: steps.check_schedule.outputs.should_release == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      
+      - name: Create release branch
+        if: steps.check_schedule.outputs.should_release == 'true'
+        id: create_branch
+        env:
+          VERSION: ${{ steps.next_version.outputs.VERSION }}
+        run: |
+          BRANCH_NAME="release-${VERSION}"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      
+      - name: Create release commit
+        if: steps.check_schedule.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.next_version.outputs.VERSION }}
+        run: |
+          # Update version and create signed commit
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" crates/lib/Cargo.toml
+          cargo update --workspace
+          dnf -y install pandoc
+          cargo xtask update-generated
+          git add -A
+          git commit -S -m "Release ${VERSION}"
+      
+      - name: Push branch
+        if: steps.check_schedule.outputs.should_release == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.create_branch.outputs.branch_name }}
+        run: |
+          git push origin "${BRANCH_NAME}"
+      
+      - name: Create Pull Request
+        if: steps.check_schedule.outputs.should_release == 'true'
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.next_version.outputs.VERSION }}
+          BRANCH_NAME: ${{ steps.create_branch.outputs.branch_name }}
+        with:
+          script: |
+            const version = process.env.VERSION;
+            const branchName = process.env.BRANCH_NAME;
+            
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release ${version}`,
+              body: `## Release ${version}
+            
+            This is an automated release PR created by the scheduled release workflow.
+            
+            ### Release Process
+            
+            1. Review the changes in this PR
+            2. Ensure all tests pass
+            3. Merge the PR
+            4. The release tag will be automatically created and signed when this PR is merged
+            
+            The release workflow will automatically trigger when the tag is pushed.`,
+              head: branchName,
+              base: 'main',
+              draft: false
+            });
+            
+            // Add the release label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['release']
+            });
+            
+            console.log(`Created PR #${pr.number}: ${pr.html_url}`);

--- a/Makefile
+++ b/Makefile
@@ -99,3 +99,48 @@ vendor:
 package-rpm:
 	cargo xtask $@
 .PHONY: package-rpm
+
+# Create a release commit with updated version
+# Usage: make release-commit VERSION=1.5.0
+release-commit:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release-commit VERSION=1.5.0"; \
+		exit 1; \
+	fi
+	@echo "Creating release commit for version $(VERSION)..."
+	# Update version in lib/Cargo.toml
+	sed -i 's/^version = ".*"/version = "$(VERSION)"/' crates/lib/Cargo.toml
+	# Update Cargo.lock with new version
+	cargo update --workspace
+	# Run cargo xtask update-generated to update generated files
+	cargo xtask update-generated
+	# Stage all changes
+	git add crates/lib/Cargo.toml Cargo.lock
+	git add -A  # Add any files updated by cargo xtask update-generated
+	# Create commit
+	git commit -m "Release $(VERSION)"
+	# Create signed tag
+	git tag -s -m "Release $(VERSION)" v$(VERSION)
+.PHONY: release-commit
+
+# Get the next minor version by bumping the minor version from crates/lib/Cargo.toml
+# Outputs the new version string (e.g., "1.3.0" if current version is "1.2.4")
+next-minor-version:
+	@VERSION=$$(grep '^version' crates/lib/Cargo.toml | sed 's/version = "//;s/"//'); \
+	if [ -z "$$VERSION" ]; then \
+		echo "Error: Could not find version in crates/lib/Cargo.toml" >&2; \
+		exit 1; \
+	fi; \
+	if ! echo "$$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' >/dev/null; then \
+		echo "Error: Invalid version format in Cargo.toml: $$VERSION" >&2; \
+		exit 1; \
+	fi; \
+	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
+	MINOR=$$(echo "$$VERSION" | cut -d. -f2); \
+	if ! [ "$$MAJOR" -eq "$$MAJOR" ] 2>/dev/null || ! [ "$$MINOR" -eq "$$MINOR" ] 2>/dev/null; then \
+		echo "Error: Invalid version numbers in $$VERSION" >&2; \
+		exit 1; \
+	fi; \
+	NEW_MINOR=$$((MINOR + 1)); \
+	echo "$$MAJOR.$$NEW_MINOR.0"
+.PHONY: next-minor-version


### PR DESCRIPTION
This adds two github actions, "Create Release PR" and "release". The first is scheduled to run every 3 weeks to automatically create a release PR that bumps the versions. The "release" action is triggered when the release PR is merged. It will create a draft release with the tars attached.

Assited-by: Claude Code