### PR TITLE
ci: Drop ppc64le COPR builds from presubmits

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,15 +36,12 @@ jobs:
       # for all architectures
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
-      - centos-stream-9-ppc64le
       - centos-stream-9-s390x
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
-      - centos-stream-10-ppc64le
       - centos-stream-10-s390x
       - fedora-41-x86_64
       - fedora-41-aarch64
-      - fedora-41-ppc64le
       - fedora-41-s390x
       # Sanity check on secondary targets, fewer architectures just
       # because the chance that we break e.g. ppc64le *just* on


### PR DESCRIPTION
These are failing due to infra issues apparently, and we have coverage at release time, we really don't
need to build every single PR by default.