### PR TITLE
reboot: Quiet the output from systemd-run

### DIFF
--- a/crates/lib/src/reboot.rs
+++ b/crates/lib/src/reboot.rs
@@ -14,7 +14,13 @@ pub(crate) fn reboot() -> anyhow::Result<()> {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     Task::new("Rebooting system", "systemd-run")
-        .args(["--", "systemctl", "reboot", "--message=Initiated by bootc"])
+        .args([
+            "--quiet",
+            "--",
+            "systemctl",
+            "reboot",
+            "--message=Initiated by bootc",
+        ])
         .run()?;
     tracing::debug!("Initiated reboot, sleeping forever...");
     loop {


### PR DESCRIPTION
The fact that we have a transient unit here is just implementation detail, no need to tell the user the name of the unit.