### PR TITLE
install: use deployed sysroot as root for bootloader install

### DIFF
--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -14,16 +14,19 @@ pub(crate) fn install_via_bootupd(
     device: &PartitionTable,
     rootfs: &Utf8Path,
     configopts: &crate::install::InstallConfigOpts,
+    deployment_path: &str,
 ) -> Result<()> {
     let verbose = std::env::var_os("BOOTC_BOOTLOADER_DEBUG").map(|_| "-vvvv");
     // bootc defaults to only targeting the platform boot method.
     let bootupd_opts = (!configopts.generic_image).then_some(["--update-firmware", "--auto"]);
 
+    let srcroot = rootfs.join(deployment_path);
     let devpath = device.path();
     let args = ["backend", "install", "--write-uuid"]
         .into_iter()
         .chain(verbose)
         .chain(bootupd_opts.iter().copied().flatten())
+        .chain(["--src-root", srcroot.as_str()])
         .chain(["--device", devpath.as_str(), rootfs.as_str()]);
     Task::new("Running bootupctl to install bootloader", "bootupctl")
         .args(args)

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1347,7 +1347,7 @@ async fn install_with_sysroot(
 ) -> Result<()> {
     // And actually set up the container in that root, returning a deployment and
     // the aleph state (see below).
-    let (_deployment, aleph) = install_container(state, rootfs, &sysroot, has_ostree).await?;
+    let (deployment, aleph) = install_container(state, rootfs, &sysroot, has_ostree).await?;
     // Write the aleph data that captures the system state at the time of provisioning for aid in future debugging.
     rootfs
         .physical_root
@@ -1355,6 +1355,8 @@ async fn install_with_sysroot(
             anyhow::Ok(aleph.to_canon_json_writer(f)?)
         })
         .context("Writing aleph version")?;
+
+    let deployment_path = sysroot.deployment_dirpath(&deployment);
 
     if cfg!(target_arch = "s390x") {
         // TODO: Integrate s390x support into install_via_bootupd
@@ -1364,6 +1366,7 @@ async fn install_with_sysroot(
             &rootfs.device_info,
             &rootfs.physical_root_path,
             &state.config_opts,
+            &deployment_path.as_str(),
         )?;
     }
     tracing::debug!("Installed bootloader");


### PR DESCRIPTION
Tell bootupctl to load components from the deployed image rather than expecting we are running in the container (or assume that the buildroot is the container.)
As the image content is already deployed at this stage, pointing to it makes it work in both scenarios (different buildroot or running from the container.)

Fixes https://github.com/bootc-dev/bootc/issues/1455