### PR TITLE
tree-wide: Clean up our re-exec path

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -685,7 +685,7 @@ pub(crate) fn ensure_self_unshared_mount_namespace() -> Result<()> {
             anyhow::bail!("Failed to unshare mount namespace");
         }
     }
-    crate::reexec::reexec_with_guardenv(recurse_env, &["unshare", "-m", "--"])
+    bootc_utils::reexec::reexec_with_guardenv(recurse_env, &["unshare", "-m", "--"])
 }
 
 /// Acquire a locked sysroot.

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -914,11 +914,11 @@ async fn install_container(
 }
 
 /// Run a command in the host mount namespace
-pub(crate) fn run_in_host_mountns(cmd: &str) -> Command {
-    let mut c = Command::new("/proc/self/exe");
+pub(crate) fn run_in_host_mountns(cmd: &str) -> Result<Command> {
+    let mut c = Command::new(bootc_utils::reexec::executable_path()?);
     c.lifecycle_bind()
         .args(["exec-in-host-mount-namespace", cmd]);
-    c
+    Ok(c)
 }
 
 #[context("Re-exec in host mountns")]

--- a/crates/lib/src/install/baseline.rs
+++ b/crates/lib/src/install/baseline.rs
@@ -152,7 +152,7 @@ pub(crate) fn udev_settle() -> Result<()> {
     // our way out of this.
     std::thread::sleep(std::time::Duration::from_millis(200));
 
-    let st = super::run_in_host_mountns("udevadm")
+    let st = super::run_in_host_mountns("udevadm")?
         .arg("settle")
         .status()?;
     if !st.success() {

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -21,7 +21,6 @@ pub(crate) mod metadata;
 mod podman;
 mod progress_jsonl;
 mod reboot;
-mod reexec;
 pub mod spec;
 mod status;
 mod store;

--- a/crates/lib/src/podman.rs
+++ b/crates/lib/src/podman.rs
@@ -24,7 +24,7 @@ pub(crate) struct ImageListEntry {
 /// Given an image ID, return its manifest digest
 pub(crate) fn imageid_to_digest(imgid: &str) -> Result<String> {
     use bootc_utils::CommandRunExt;
-    let o: Vec<Inspect> = crate::install::run_in_host_mountns("podman")
+    let o: Vec<Inspect> = crate::install::run_in_host_mountns("podman")?
         .args(["inspect", imgid])
         .run_and_parse_json()?;
     let i = o

--- a/crates/ostree-ext/src/container/deploy.rs
+++ b/crates/ostree-ext/src/container/deploy.rs
@@ -152,7 +152,7 @@ pub async fn deploy(
 
             // Note that the sysroot is provided as `.`  but we use cwd_dir to
             // make the process current working directory the sysroot.
-            let st = std::process::Command::new("/proc/self/exe")
+            let st = std::process::Command::new(std::env::current_exe()?)
                 .args(["internals", "bootc-install-completion", ".", stateroot])
                 .cwd_dir(sysroot_dir.try_clone()?)
                 .lifecycle_bind()

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -12,3 +12,5 @@ mod timestamp;
 pub use timestamp::*;
 mod tracing_util;
 pub use tracing_util::*;
+/// Re-execute the current process
+pub mod reexec;

--- a/crates/utils/src/reexec.rs
+++ b/crates/utils/src/reexec.rs
@@ -1,17 +1,30 @@
 use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::Result;
-use fn_error_context::context;
+
+/// Environment variable holding a reference to our original binary
+pub const ORIG: &str = "_BOOTC_ORIG_EXE";
+
+/// Return the path to our own executable. In some cases (SELinux) we may have
+/// performed a re-exec with a temporary copy of the binary and
+/// this environment variable will hold the path to the original binary.
+pub fn executable_path() -> Result<PathBuf> {
+    if let Some(p) = std::env::var_os(ORIG) {
+        Ok(p.into())
+    } else {
+        std::env::current_exe().map_err(Into::into)
+    }
+}
 
 /// Re-execute the current process if the provided environment variable is not set.
-#[context("Reexec self")]
-pub(crate) fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
+pub fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
     if std::env::var_os(k).is_some() {
         tracing::trace!("Skipping re-exec due to env var {k}");
         return Ok(());
     }
-    let self_exe = std::fs::read_link("/proc/self/exe")?;
+    let self_exe = executable_path()?;
     let mut prefix_args = prefix_args.iter();
     let mut cmd = if let Some(p) = prefix_args.next() {
         let mut c = Command::new(p);


### PR DESCRIPTION
Prep for fixing https://github.com/bootc-dev/bootc/issues/1434

Basically in the selinux path we copy our binary to a tempfile, which breaks `/proc/self/exe`.

Fix this by setting an environment variable when we do that re-exec and ensuring that *everything* references an internal API (now moved to utils/ so it can be shared) that looks for the env var first.