### PR TITLE
docs: add Playtron GameOS

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -25,6 +25,7 @@ is to be the successor to ostree, and it is our aim to seamlessly carry forward 
 | Vendor | Red Hat | 2015 | [link](https://redhat.com) | Image Based Linux
 | Vendor | Apertis | 2020 | [link](https://apertis.org) | Collaborative OS platform for products
 | Vendor | Fedora Project | 2021 | [link](https://fedoraproject.org/atomic-desktops/) | An atomic desktop operating system aimed at good support for container-focused workflows
+| Vendor | Playtron GameOS | 2022 | [link](https://www.playtron.one/) | A video game console OS that has integration with the top PC game stores |
 | Vendor | Universal Blue   | 2022 | [link](https://universal-blue.org/) | The reliability of a Chromebook, but with the flexibility and power of a traditional Linux desktop
 | Vendor | Fyra Labs | 2024 | [link](https://fyralabs.com) | Bootc powers an experimental variant of Ultramarine Linux
 


### PR DESCRIPTION
to the ADOPTERS.md. We have builds dating all the way back to 2022.