### PR TITLE
reboot: Drop use of Task

### DIFF
--- a/crates/lib/src/reboot.rs
+++ b/crates/lib/src/reboot.rs
@@ -1,10 +1,9 @@
 //! Handling of system restarts/reboot
 
-use std::io::Write;
+use std::{io::Write, process::Command};
 
+use bootc_utils::CommandRunExt;
 use fn_error_context::context;
-
-use crate::task::Task;
 
 /// Initiate a system reboot.
 /// This function will only return in case of error.
@@ -13,7 +12,7 @@ pub(crate) fn reboot() -> anyhow::Result<()> {
     // Flush output streams
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
-    Task::new("Rebooting system", "systemd-run")
+    Command::new("systemd-run")
         .args([
             "--quiet",
             "--",
@@ -21,8 +20,13 @@ pub(crate) fn reboot() -> anyhow::Result<()> {
             "reboot",
             "--message=Initiated by bootc",
         ])
-        .run()?;
-    tracing::debug!("Initiated reboot, sleeping forever...");
+        .run_capture_stderr()?;
+    // We expect to be terminated via SIGTERM here. We sleep
+    // instead of exiting an exit would necessarily appear
+    // racy to calling processes in that sometimes we'd
+    // win the race to exit, other times might get killed
+    // via SIGTERM.
+    tracing::debug!("Initiated reboot, sleeping");
     loop {
         std::thread::park();
     }


### PR DESCRIPTION
It was not a useful abstraction in the end, just remove it.

While here, also extend a comment with rationale for why we sleep.