### PR TITLE
Fix autovendor workflow CLI directory path

### DIFF
--- a/.github/workflows/autovendor.yml
+++ b/.github/workflows/autovendor.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install vendor tool
         run: cargo install cargo-vendor-filterer
       - name: Run
-        run: mkdir -p target && cd cli && cargo vendor-filterer --format=tar.zstd --prefix=vendor/ ../target/vendor.tar.zst
+        run: mkdir -p target && cd crates/cli && cargo vendor-filterer --format=tar.zstd --prefix=vendor/ ../../target/vendor.tar.zst
       - uses: actions/upload-artifact@v4
         with:
           name: vendor.tar.zst


### PR DESCRIPTION
Update the autovendor GitHub workflow to use the correct path 'crates/cli'
instead of 'cli', which was causing the job to fail with "No such file or
directory" error.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
