### PR TITLE
Fix warnings for `mismatched_lifetime_syntaxes` lint

### DIFF
--- a/crates/lib/src/parsers/grub_menuconfig.rs
+++ b/crates/lib/src/parsers/grub_menuconfig.rs
@@ -142,7 +142,7 @@ pub fn take_until_balanced_allow_nested(
 
 /// Parses a single menuentry with title and body commands.
 #[allow(dead_code)]
-fn parse_menuentry(input: &str) -> IResult<&str, MenuEntry> {
+fn parse_menuentry(input: &str) -> IResult<&str, MenuEntry<'_>> {
     let (input, _) = tag("menuentry").parse(input)?;
 
     // Require at least one space after "menuentry"
@@ -198,7 +198,7 @@ fn skip_to_menuentry(input: &str) -> IResult<&str, ()> {
 
 /// Parses all menuentries from a GRUB configuration file.
 #[allow(dead_code)]
-fn parse_all(input: &str) -> IResult<&str, Vec<MenuEntry>> {
+fn parse_all(input: &str) -> IResult<&str, Vec<MenuEntry<'_>>> {
     let mut remaining = input;
     let mut entries = Vec::new();
 
@@ -230,7 +230,7 @@ fn parse_all(input: &str) -> IResult<&str, Vec<MenuEntry>> {
 
 /// Main entry point for parsing GRUB menuentry files.
 #[allow(dead_code)]
-pub(crate) fn parse_grub_menuentry_file(contents: &str) -> anyhow::Result<Vec<MenuEntry>> {
+pub(crate) fn parse_grub_menuentry_file(contents: &str) -> anyhow::Result<Vec<MenuEntry<'_>>> {
     let (_, entries) = parse_all(&contents)
         .map_err(|e| anyhow::anyhow!("Failed to parse GRUB menuentries: {e}"))?;
     // Validate that entries have reasonable structure

--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -32,7 +32,7 @@ pub(crate) fn origin_has_rpmostree_stuff(kf: &glib::KeyFile) -> bool {
 
 // Access the file descriptor for a sysroot
 #[allow(unsafe_code)]
-pub(crate) fn sysroot_fd(sysroot: &ostree::Sysroot) -> BorrowedFd {
+pub(crate) fn sysroot_fd(sysroot: &ostree::Sysroot) -> BorrowedFd<'_> {
     unsafe { BorrowedFd::borrow_raw(sysroot.fd()) }
 }
 

--- a/crates/ostree-ext/src/container/deploy.rs
+++ b/crates/ostree-ext/src/container/deploy.rs
@@ -56,7 +56,7 @@ pub struct DeployOpts<'a> {
 // Access the file descriptor for a sysroot
 #[allow(unsafe_code)]
 #[cfg(feature = "bootc")]
-pub(crate) fn sysroot_fd(sysroot: &ostree::Sysroot) -> BorrowedFd {
+pub(crate) fn sysroot_fd(sysroot: &ostree::Sysroot) -> BorrowedFd<'_> {
     unsafe { BorrowedFd::borrow_raw(sysroot.fd()) }
 }
 

--- a/crates/ostree-ext/src/fixture.rs
+++ b/crates/ostree-ext/src/fixture.rs
@@ -340,7 +340,7 @@ fn ensure_parent_dirs(
         .map_err(Into::into)
 }
 
-fn relative_path_components(p: &Utf8Path) -> impl Iterator<Item = Utf8Component> {
+fn relative_path_components(p: &Utf8Path) -> impl Iterator<Item = Utf8Component<'_>> {
     p.components()
         .filter(|p| matches!(p, Utf8Component::Normal(_)))
 }

--- a/crates/ostree-ext/src/tar/export.rs
+++ b/crates/ostree-ext/src/tar/export.rs
@@ -75,13 +75,13 @@ fn map_path_inner<'p>(
 }
 
 /// Convert /usr/etc back to /etc
-fn map_path(p: &Utf8Path) -> std::borrow::Cow<Utf8Path> {
+fn map_path(p: &Utf8Path) -> std::borrow::Cow<'_, Utf8Path> {
     map_path_inner(p, "./usr/etc", "./etc")
 }
 
 /// Convert etc to usr/etc
 /// Note: no leading '/' or './'
-fn unmap_path(p: &Utf8Path) -> std::borrow::Cow<Utf8Path> {
+fn unmap_path(p: &Utf8Path) -> std::borrow::Cow<'_, Utf8Path> {
     map_path_inner(p, "etc", "usr/etc")
 }
 

--- a/crates/ostree-ext/src/tar/write.rs
+++ b/crates/ostree-ext/src/tar/write.rs
@@ -142,7 +142,7 @@ pub(crate) struct TarImportConfig {
 }
 
 // If a path starts with /etc or ./etc or etc, remap it to be usr/etc.
-fn remap_etc_path(path: &Utf8Path) -> Cow<Utf8Path> {
+fn remap_etc_path(path: &Utf8Path) -> Cow<'_, Utf8Path> {
     let mut components = path.components();
     let Some(prefix) = components.next() else {
         return Cow::Borrowed(path);


### PR DESCRIPTION
Rust 1.89 introduced this new lint[1], fix the handful of places where
it comes up across the repo.

[1] https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
