### PR TITLE
Add initramfs infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bootc-initramfs-setup"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "bootc-internal-blockdev"
 version = "0.0.0"
 dependencies = [

--- a/crates/initramfs/Cargo.toml
+++ b/crates/initramfs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bootc-initramfs-setup"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/crates/initramfs/bootc-root-setup.service
+++ b/crates/initramfs/bootc-root-setup.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=bootc setup root
+Documentation=man:bootc(1)
+DefaultDependencies=no
+# For now
+ConditionKernelCommandLine=ostree
+ConditionPathExists=/etc/initrd-release
+After=sysroot.mount
+After=ostree-prepare-root.service
+Requires=sysroot.mount
+Before=initrd-root-fs.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/bootc/initramfs-setup setup-root
+StandardInput=null
+StandardOutput=journal
+StandardError=journal+console
+RemainAfterExit=yes

--- a/crates/initramfs/dracut/module-setup.sh
+++ b/crates/initramfs/dracut/module-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+installkernel() {
+    instmods erofs overlay
+}
+check() {
+    require_binaries /usr/lib/bootc/initramfs-setup || return 1
+}
+depends() {
+    return 0
+}
+install() {
+    local service=bootc-root-setup.service
+    dracut_install /usr/lib/bootc/initramfs-setup
+    inst_simple "${systemdsystemunitdir}/${service}"
+    mkdir -p "${initdir}${systemdsystemconfdir}/initrd-root-fs.target.wants"
+    ln_r "${systemdsystemunitdir}/${service}" \
+        "${systemdsystemconfdir}/initrd-root-fs.target.wants/${service}"
+}

--- a/crates/initramfs/src/main.rs
+++ b/crates/initramfs/src/main.rs
@@ -1,0 +1,24 @@
+//! Code for bootc that goes into the initramfs.
+//! At the current time, this is mostly just a no-op.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::Result;
+
+fn setup_root() -> Result<()> {
+    let _ = std::fs::metadata("/sysroot/usr")?;
+    println!("setup OK");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let v = std::env::args().collect::<Vec<_>>();
+    let args = match v.as_slice() {
+        [] => anyhow::bail!("Missing argument".to_string()),
+        [_, rest @ ..] => rest,
+    };
+    match args {
+        [] => anyhow::bail!("Missing argument".to_string()),
+        [s] if s == "setup-root" => setup_root(),
+        [o, ..] => anyhow::bail!(format!("Unknown command {o}")),
+    }
+}

--- a/tmt/tests/booted/readonly/051-test-initramfs.nu
+++ b/tmt/tests/booted/readonly/051-test-initramfs.nu
@@ -1,0 +1,13 @@
+use std assert
+use tap.nu
+
+tap begin "initramfs"
+
+if (not ("/usr/lib/bootc/initramfs-setup" | path exists)) {
+    print "No initramfs support"
+    exit 0
+}
+
+journalctl -b -t bootc-root-setup.service --grep=OK
+
+tap ok


### PR DESCRIPTION
This adds scaffolding to install a stub binary which can optionally be added into the initramfs;
prep for us doing real work during setup as we aim to move to the native composefs backend.

The binary is *built* but is only installed by a
new `Makefile` target, so existing build system
users won't pick it up. Our development-only
`Dockerfile` gains a build option to use it
(and also ensures the initramfs is regenerated).

However previously we also discussed moving the fstab logic into the initramfs:
https://github.com/bootc-dev/bootc/pull/1113

I might try doing that once this lands.

One notable thing is that even this trivial nearly-no-op binary is still 4MB which I think is mostly due
to linking in a whole copy of prebuilt rust `std`. In theory we could try going to `#[no_std]` but I
don't think it'll be viable once we start doing more here. Probably most practical thing re size is `-Z build-std` + LTO.