### PR TITLE
fix(blockdev): include "internals" when spawning loopback-cleanup-helper

### DIFF
--- a/crates/blockdev/src/blockdev.rs
+++ b/crates/blockdev/src/blockdev.rs
@@ -251,7 +251,12 @@ impl LoopbackDevice {
 
         // Create the helper process
         let mut cmd = Command::new(bootc_path);
-        cmd.args(["loopback-cleanup-helper", "--device", device_path]);
+        cmd.args([
+            "internals",
+            "loopback-cleanup-helper",
+            "--device",
+            device_path,
+        ]);
 
         // Set environment variable to indicate this is a cleanup helper
         cmd.env("BOOTC_LOOPBACK_CLEANUP_HELPER", "1");


### PR DESCRIPTION
Adds the missing `internals` subcommand when spawning `loopback-cleanup-helper` so it runs as intended during `bootc install --via-loopback`. Without `internals`, the helper fails with `unrecognized subcommand 'loopback-cleanup-helper'`, preventing loop device cleanup. This doesn’t block install/boot because the helper is fire-and-forget, but it leaves loop devices uncleared.

Fixes: #1510