### PR TITLE
ci/tmt: distro-sync ostree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ case $ID in
   centos|rhel) dnf config-manager --set-enabled crb;;
   fedora) dnf -y install dnf-utils 'dnf5-command(builddep)';;
 esac
+# Handle version skew, xref https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1174
+dnf -y distro-sync ostree{,-libs} systemd
 dnf -y builddep /tmp/bootc.spec
 # Extra dependencies
 dnf -y install git-core

--- a/tmt/tests/bootc-install-provision.sh
+++ b/tmt/tests/bootc-install-provision.sh
@@ -119,6 +119,8 @@ case $ID in
   centos|rhel) dnf config-manager --set-enabled crb;;
   fedora) dnf -y install dnf-utils 'dnf5-command(builddep)';;
 esac
+# Handle version skew
+dnf -y distro-sync ostree{,-libs} systemd
 dnf -y builddep contrib/packaging/bootc.spec
 # Extra dependencies
 dnf -y install git-core


### PR DESCRIPTION
This is a hackaround for https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1174