### PR TITLE
Add missing perms and fix reviewer assignment API call

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -3,30 +3,30 @@ name: Auto Assign Reviewer
 on:
   pull_request_target:
     types: [opened, ready_for_review]
-  workflow_dispatch: {}
-
-permissions:
-  pull-requests: write
-  contents: read
 
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
-    
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+      read:org: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyyaml
-          
+
       - name: Assign reviewer
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Fixing the error: `error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)` when assigning the reviewers.