### PR TITLE
install: Automatically configure aboot

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -19,6 +19,7 @@ use std::io::Write;
 use std::os::fd::{AsFd, AsRawFd};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
+use std::process;
 use std::process::Command;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -624,7 +625,11 @@ async fn initialize_ostree_root(state: &State, root_setup: &RootSetup) -> Result
     }
 
     let sysroot = {
-        let path = format!("/proc/self/fd/{}", rootfs_dir.as_fd().as_raw_fd());
+        let path = format!(
+            "/proc/{}/fd/{}",
+            process::id(),
+            rootfs_dir.as_fd().as_raw_fd()
+        );
         ostree::Sysroot::new(Some(&gio::File::for_path(path)))
     };
     sysroot.load(cancellable)?;

--- a/crates/ostree-ext/src/bootabletree.rs
+++ b/crates/ostree-ext/src/bootabletree.rs
@@ -12,6 +12,7 @@ use ostree::prelude::*;
 
 const MODULES: &str = "usr/lib/modules";
 const VMLINUZ: &str = "vmlinuz";
+const ABOOT_IMG: &str = "aboot.img";
 
 /// Find the kernel modules directory in a bootable OSTree commit.
 /// The target directory will have a `vmlinuz` file representing the kernel binary.
@@ -86,6 +87,20 @@ pub fn find_kernel_dir_fs(root: &Dir) -> Result<Option<Utf8PathBuf>> {
         }
     }
     Ok(r)
+}
+
+/// Check if there is an aboot image in the kernel tree dir
+pub fn commit_has_aboot_img(
+    root: &gio::File,
+    cancellable: Option<&gio::Cancellable>,
+) -> Result<bool> {
+    if let Some(kernel_dir) = find_kernel_dir(root, cancellable)? {
+        Ok(kernel_dir
+            .resolve_relative_path(ABOOT_IMG)
+            .query_exists(cancellable))
+    } else {
+        Ok(false)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows you to set a non-default ostree bootloader backend.  In particular, this is needed for aboot images, as otherwise  the deploy will not shell out to aboot-deploy to create the required A/B boot symlinks.

PR includes a fix to make aboot-deploy actually work.
