### PR TITLE
sysroot: Log locking to stderr, not stdout

### DIFF
--- a/crates/ostree-ext/src/sysroot.rs
+++ b/crates/ostree-ext/src/sysroot.rs
@@ -44,7 +44,7 @@ impl SysrootLock {
                 });
             }
             if !printed {
-                println!("Waiting for sysroot lock...");
+                eprintln!("Waiting for sysroot lock...");
                 printed = true;
             }
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;


### PR DESCRIPTION
Otherwise we just completely break machine readability with `bootc status --format=json`.

(We probably need a full audit to stop using `{,e}println!`
 globally)