### PR TITLE
cli: Set tokio thread name

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,6 +28,7 @@ fn run() -> Result<()> {
     // tokio::task::spawn_blocking to create a new OS thread explicitly.
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
+        .thread_name("bootc")
         .build()
         .expect("Failed to build tokio runtime");
     // And invoke the async_main


### PR DESCRIPTION
I'm doing some tracing with `bpftrace` and it shows `comm` as `tokio-runtime-w`. This ensures it shows `bootc` as one would expect.