### PR TITLE
governance: add community manager role

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,11 @@ The current Maintainers Group for the bootc Project consists of:
 | Xiaofeng Wang     | [henrywang](https://github.com/orgs/bootc-dev/people/henrywang)      | Red Hat         | Approver         |
 | Gursewak Mangat   | [gursewak1997](https://github.com/orgs/bootc-dev/people/gursewak1997)| Red Hat         | Approver         |
 | Joseph Marrero    | [jmarrero](https://github.com/orgs/bootc-dev/people/jmarrero)        | Red Hat         | Approver         |
+
+# Community Managers
+
+This group can represent the project for administrative and program manager duties. Examples: CNCF Service Desk tickets, coordinating with CNCF Project and Events teams, and LFX Administration. No code or code review rights.
+
+| Name              | GitHub ID                                                            | Employer        | Responsibilities |
+| ----              | ----                                                                 | ----            | ----             |
+| Laura Santamaria  | [nimbinatus](https://github.com/nimbinatus)                          | Red Hat         | Representative   |


### PR DESCRIPTION
Feel free to adjust wording as needed, this is just an example.

This is a good way to empower PMs other folks to be able to help out with meta things around the project. We explicitly list the the role in governance so that the people listed here end up in the main cncf maintainers.csv.

Being in the csv file is important because it is a check the CNCF uses to ensure maintainers are requesting the resources. And for CFP submissions, "did one of the maintainers submit this talk or was it someone else?", etc.