### PR TITLE
Deduplicate main error printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ dependencies = [
  "bootc-internal-utils",
  "bootc-lib",
  "log",
- "owo-colors",
  "tokio",
  "tracing",
 ]
@@ -223,8 +222,10 @@ dependencies = [
 name = "bootc-internal-utils"
 version = "0.0.0"
 dependencies = [
+ "anstream",
  "anyhow",
  "chrono",
+ "owo-colors",
  "rustix 1.0.8",
  "serde",
  "serde_json",
@@ -952,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2223,7 +2224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2548,6 +2549,7 @@ dependencies = [
 name = "system-reinstall-bootc"
 version = "0.1.9"
 dependencies = [
+ "anstream",
  "anyhow",
  "bootc-internal-utils",
  "bootc-mount",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,7 +22,6 @@ bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "
 anstream = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
-owo-colors = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,8 +1,6 @@
 //! The main entrypoint for bootc, which just performs global initialization, and then
 //! calls out into the library.
 //!
-use std::io::Write as _;
-
 use anyhow::Result;
 
 /// The code called after we've done process global init and created
@@ -35,15 +33,5 @@ fn run() -> Result<()> {
 }
 
 fn main() {
-    use owo_colors::OwoColorize;
-
-    // In order to print the error in a custom format (with :#) our
-    // main simply invokes a run() where all the work is done.
-    // This code just captures any errors.
-    if let Err(e) = run() {
-        let mut stderr = anstream::stderr();
-        // Don't panic if writing fails
-        let _ = writeln!(stderr, "{}{:#}", "error: ".red(), e);
-        std::process::exit(1);
-    }
+    bootc_utils::run_main(run)
 }

--- a/crates/system-reinstall-bootc/Cargo.toml
+++ b/crates/system-reinstall-bootc/Cargo.toml
@@ -19,6 +19,7 @@ bootc-mount = { path = "../mount" }
 bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.0.0" }
 
 # Workspace dependencies
+anstream = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 indoc = { workspace = true }

--- a/crates/system-reinstall-bootc/src/main.rs
+++ b/crates/system-reinstall-bootc/src/main.rs
@@ -66,11 +66,5 @@ fn run() -> Result<()> {
 }
 
 fn main() {
-    // In order to print the error in a custom format (with :#) our
-    // main simply invokes a run() where all the work is done.
-    // This code just captures any errors.
-    if let Err(e) = run() {
-        tracing::error!("{:#}", e);
-        std::process::exit(1);
-    }
+    bootc_utils::run_main(run)
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -8,8 +8,10 @@ repository = "https://github.com/bootc-dev/bootc"
 
 [dependencies]
 # Workspace dependencies
+anstream = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["std"] }
+owo-colors = { workspace = true }
 rustix = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -16,3 +16,21 @@ pub use tracing_util::*;
 pub mod reexec;
 mod result_ext;
 pub use result_ext::*;
+
+/// Intended for use in `main`, calls an inner function and
+/// handles errors by printing them.
+pub fn run_main<F>(f: F)
+where
+    F: FnOnce() -> anyhow::Result<()>,
+{
+    use std::io::Write as _;
+
+    use owo_colors::OwoColorize;
+
+    if let Err(e) = f() {
+        let mut stderr = anstream::stderr();
+        // Don't panic if writing fails.
+        let _ = writeln!(stderr, "{}{:#}", "error: ".red(), e);
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
As part of the tracing-subscriber CVE I did a quick audit for usages of `tracing::error!` and I noticed when we updated the `main()` function in the primary
crate we missed also doing the same for system-reinstall-bootc.

Move the handling of that to utils.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=2392017