### PR TITLE
Un-hide soft-reboot

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -85,9 +85,7 @@ pub(crate) struct UpgradeOpts {
     ///
     /// 'required' will fail if soft reboot is not available.
     /// 'auto' will use soft reboot if available, otherwise fall back to regular reboot.
-    // Hidden because the ostree side needs further stabilization.
-    // See: https://github.com/ostreedev/ostree/issues/3503
-    #[clap(long = "soft-reboot", conflicts_with = "check", hide = true)]
+    #[clap(long = "soft-reboot", conflicts_with = "check")]
     pub(crate) soft_reboot: Option<SoftRebootMode>,
 
     #[clap(flatten)]
@@ -113,9 +111,7 @@ pub(crate) struct SwitchOpts {
     ///
     /// 'required' will fail if soft reboot is not available.
     /// 'auto' will use soft reboot if available, otherwise fall back to regular reboot.
-    // Hidden because the ostree side needs further stabilization.
-    // See: https://github.com/ostreedev/ostree/issues/3503
-    #[clap(long = "soft-reboot", hide = true)]
+    #[clap(long = "soft-reboot")]
     pub(crate) soft_reboot: Option<SoftRebootMode>,
 
     /// The transport; e.g. oci, oci-archive, containers-storage.  Defaults to `registry`.
@@ -166,9 +162,7 @@ pub(crate) struct RollbackOpts {
     ///
     /// 'required' will fail if soft reboot is not available.
     /// 'auto' will use soft reboot if available, otherwise fall back to regular reboot.
-    // Hidden because the ostree side needs further stabilization.
-    // See: https://github.com/ostreedev/ostree/issues/3503
-    #[clap(long = "soft-reboot", hide = true)]
+    #[clap(long = "soft-reboot")]
     pub(crate) soft_reboot: Option<SoftRebootMode>,
 }
 

--- a/tmt/tests/booted/readonly/002-test-cli.nu
+++ b/tmt/tests/booted/readonly/002-test-cli.nu
@@ -5,4 +5,7 @@ tap begin "verify bootc status output formats"
 
 assert equal (bootc switch blah:// e>| find "\u{1B}") []
 
+# Verify soft-reboot is in help
+bootc upgrade --help | grep -qF -e '--soft-reboot'
+
 tap ok


### PR DESCRIPTION
We debugged https://github.com/ostreedev/ostree/issues/3503 and it's basically a systemd/Anaconda bug. So we can consider soft reboots an available feature from our end (as systemd does), but certainly one that will require integration testing on the OS/distro side.

If you're building a system and you don't want to enable soft reboots, just `rm /usr/lib/systemd/system/soft-reboot.target` or so should do the trick.