### PR TITLE
cfs: only get sysroot storage when repo is not supplied

### DIFF
--- a/crates/lib/src/cfsctl.rs
+++ b/crates/lib/src/cfsctl.rs
@@ -151,7 +151,7 @@ fn verity_opt(opt: &Option<String>) -> Result<Option<Sha512HashValue>> {
     Ok(opt.as_ref().map(FsVerityHashValue::from_hex).transpose()?)
 }
 
-pub(crate) async fn run_from_iter<I>(system_store: &crate::store::Storage, args: I) -> Result<()>
+pub(crate) async fn run_from_iter<I>(args: I) -> Result<()>
 where
     I: IntoIterator,
     I::Item: Into<OsString> + Clone,
@@ -172,6 +172,7 @@ where
         if args.insecure {
             anyhow::bail!("Cannot override insecure state for system repo");
         }
+        let system_store = crate::cli::get_storage().await?;
         system_store.get_ensure_composefs()?
     };
     let repo = &repo;

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1429,10 +1429,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     Ok(())
                 }
             },
-            InternalsOpts::Cfs { args } => {
-                let sysroot = &get_storage().await?;
-                crate::cfsctl::run_from_iter(sysroot, args.iter()).await
-            }
+            InternalsOpts::Cfs { args } => crate::cfsctl::run_from_iter(args.iter()).await,
             InternalsOpts::Reboot => crate::reboot::reboot(),
             InternalsOpts::Fsck => {
                 let sysroot = &get_storage().await?;


### PR DESCRIPTION
For image building, we want to be able to run this on a non-bootc host
or in a container.  There we'll manipulate the composefs repo in a
provided tempdir.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
