### PR TITLE
Update reboot-required file with information about the staged image

### DIFF
--- a/crates/lib/src/deploy.rs
+++ b/crates/lib/src/deploy.rs
@@ -794,9 +794,10 @@ pub(crate) async fn stage(
 
     // Unconditionally create or update /run/reboot-required to signal a reboot is needed.
     // This is monitored by kured (Kubernetes Reboot Daemon).
+    let reboot_message = format!("bootc: Reboot required for image: {}", &spec.image.image);
     let run_dir = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
     run_dir
-        .atomic_write("reboot-required", b"")
+        .atomic_write("reboot-required", reboot_message.as_bytes())
         .context("Creating /run/reboot-required")?;
 
     Ok(())

--- a/tmt/tests/booted/test-image-pushpull-upgrade.nu
+++ b/tmt/tests/booted/test-image-pushpull-upgrade.nu
@@ -65,9 +65,9 @@ RUN echo test content > /usr/share/blah.txt
     let progress = open --raw $progress_json | from json -o
     sanity_check_switch_progress_json $progress
 
-    # Check that /run/reboot-required exists and is a zero-byte file
+    # Check that /run/reboot-required exists and is not empty
     let rr_meta = (ls /run/reboot-required | first)
-    assert equal $rr_meta.size 0b
+    assert ($rr_meta.size > 0b)
 
     # Also test that the mtime changes on modification
     let new_root_mtime = ls -Dl /ostree/bootc | get modified


### PR DESCRIPTION
This change updates the /run/reboot-required file to include information
about the staged bootc image. This will provide users with information
about what bootc image will be effective after the system has been
rebooted.

Fixes #1574