### PR TITLE
Bump containers-image-proxy, ocidir, oci-spec and composefs-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=ce28ee8a7b43290941d208c8ca820150a6504d5a#ce28ee8a7b43290941d208c8ca820150a6504d5a"
+source = "git+https://github.com/containers/composefs-rs?rev=8402af606ff0866a6c4d891264cfac869da22ed7#8402af606ff0866a6c4d891264cfac869da22ed7"
 dependencies = [
  "anyhow",
  "hex",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "composefs-boot"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=ce28ee8a7b43290941d208c8ca820150a6504d5a#ce28ee8a7b43290941d208c8ca820150a6504d5a"
+source = "git+https://github.com/containers/composefs-rs?rev=8402af606ff0866a6c4d891264cfac869da22ed7#8402af606ff0866a6c4d891264cfac869da22ed7"
 dependencies = [
  "anyhow",
  "composefs",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "composefs-oci"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=ce28ee8a7b43290941d208c8ca820150a6504d5a#ce28ee8a7b43290941d208c8ca820150a6504d5a"
+source = "git+https://github.com/containers/composefs-rs?rev=8402af606ff0866a6c4d891264cfac869da22ed7#8402af606ff0866a6c4d891264cfac869da22ed7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9953374bea7d415048415d1f871ba974897209ba0c14d3c665d4a41bdc15628d"
+checksum = "08ca6531917f9b250bf6a1af43603b2e083c192565774451411f9bf4f8bf8f2b"
 dependencies = [
  "cap-std-ext",
  "futures-util",
@@ -693,7 +693,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
 ]
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e9beda9d92fac7bf4904c34c83340ef1024159faee67179a04e0277523da33"
+checksum = "2078e2f6be932a4de9aca90a375a45590809dfb5a08d93ab1ee217107aceeb67"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -1749,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "ocidir"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca884bf1922890f5fb3c48bbe92b450781ddb4754a4efd6b2dd1667730f9dab"
+checksum = "92e746e3e6a7bb57a72ea4f0b8085f84aedaab1d537a5dc5488fd3cd5af0cd67"
 dependencies = [
  "camino",
  "canon-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ cap-std-ext = "4.0.3"
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.4"
 clap_mangen = { version = "0.2.20" }
-composefs = { git = "https://github.com/containers/composefs-rs", rev = "ce28ee8a7b43290941d208c8ca820150a6504d5a", package = "composefs", features = ["rhel9"] }
-composefs-boot = { git = "https://github.com/containers/composefs-rs", rev = "ce28ee8a7b43290941d208c8ca820150a6504d5a", package = "composefs-boot" }
-composefs-oci = { git = "https://github.com/containers/composefs-rs", rev = "ce28ee8a7b43290941d208c8ca820150a6504d5a", package = "composefs-oci" }
+composefs = { git = "https://github.com/containers/composefs-rs", rev = "8402af606ff0866a6c4d891264cfac869da22ed7", package = "composefs", features = ["rhel9"] }
+composefs-boot = { git = "https://github.com/containers/composefs-rs", rev = "8402af606ff0866a6c4d891264cfac869da22ed7", package = "composefs-boot" }
+composefs-oci = { git = "https://github.com/containers/composefs-rs", rev = "8402af606ff0866a6c4d891264cfac869da22ed7", package = "composefs-oci" }
 fn-error-context = "0.2.1"
 hex = "0.4.3"
 indicatif = "0.18.0"

--- a/crates/ostree-ext/Cargo.toml
+++ b/crates/ostree-ext/Cargo.toml
@@ -41,14 +41,14 @@ xshell = { workspace = true, optional = true }
 
 # Crate-specific dependencies
 comfy-table = "7.1.1"
-containers-image-proxy = "0.8.0"
+containers-image-proxy = "0.9.0"
 flate2 = { features = ["zlib"], default-features = false, version = "1.0.20" }
 futures-util = "0.3.13"
 gvariant = "0.5.0"
 indexmap = { version = "2.2.2", features = ["serde"] }
 io-lifetimes = "3"
 libsystemd = "0.7.0"
-ocidir = "0.4.0"
+ocidir = "0.6.0"
 # We re-export this library too.
 ostree = { features = ["v2025_3"], version = "0.20.3" }
 pin-project = "1.0"

--- a/crates/ostree-ext/src/cli.rs
+++ b/crates/ostree-ext/src/cli.rs
@@ -942,7 +942,7 @@ async fn container_history(repo: &ostree::Repo, imgref: &ImageReference) -> Resu
         .set_content_arrangement(comfy_table::ContentArrangement::Dynamic)
         .set_header(["ID", "SIZE", "CRCEATED BY"]);
 
-    let mut history = img.configuration.history().iter();
+    let mut history = img.configuration.history().iter().flatten();
     let layers = img.manifest.layers().iter();
     for layer in layers {
         let histent = history.next();

--- a/crates/ostree-ext/tests/it/main.rs
+++ b/crates/ostree-ext/tests/it/main.rs
@@ -574,7 +574,7 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
 
     let n_chunks = if chunked { LAYERS_V0_LEN } else { 1 };
     assert_eq!(cfg.rootfs().diff_ids().len(), n_chunks);
-    assert_eq!(cfg.history().len(), n_chunks);
+    assert_eq!(cfg.history().as_ref().unwrap().len(), n_chunks);
 
     // Verify exporting to ociarchive
     {


### PR DESCRIPTION
The first three are all entangled because of a messy oci-spec semver incompatibility
https://github.com/youki-dev/oci-spec-rs/pull/288

Bumping composefs-rs is just to avoid having two versions of the proxy in the lockfile.

Closes: https://github.com/bootc-dev/bootc/issues/1567