### PR TITLE
log to journal if root

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1215,9 +1215,8 @@ async fn usroverlay() -> Result<()> {
 pub fn global_init() -> Result<()> {
     // In some cases we re-exec with a temporary binary,
     // so ensure that the syslog identifier is set.
-    let name = "bootc";
-    ostree::glib::set_prgname(name.into());
-    if let Err(e) = rustix::thread::set_name(&CString::new(name).unwrap()) {
+    ostree::glib::set_prgname(bootc_utils::NAME.into());
+    if let Err(e) = rustix::thread::set_name(&CString::new(bootc_utils::NAME).unwrap()) {
         // This shouldn't ever happen
         eprintln!("failed to set name: {e}");
     }

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -910,7 +910,7 @@ fn prepare_for_write() -> Result<()> {
     crate::cli::require_root(false)?;
     ensure_self_unshared_mount_namespace()?;
     if crate::lsm::selinux_enabled()? && !crate::lsm::selinux_ensure_install()? {
-        tracing::warn!("Do not have install_t capabilities");
+        tracing::debug!("Do not have install_t capabilities");
     }
     ENTERED.store(true, Ordering::SeqCst);
     Ok(())

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -918,7 +918,7 @@ pub(crate) fn exec_in_host_mountns(args: &[std::ffi::OsString]) -> Result<()> {
         tracing::debug!("Using supermin workaround");
         rustix::process::chroot("/root").context("chroot")?;
     }
-    Err(Command::new(cmd).args(args).exec()).context("exec")?
+    Err(Command::new(cmd).args(args).arg0(bootc_utils::NAME).exec()).context("exec")?
 }
 
 pub(crate) struct RootSetup {

--- a/crates/lib/src/lsm.rs
+++ b/crates/lib/src/lsm.rs
@@ -110,6 +110,7 @@ pub(crate) fn selinux_ensure_install() -> Result<bool> {
     cmd.env(guardenv, tmpf);
     cmd.env(bootc_utils::reexec::ORIG, srcpath);
     cmd.args(std::env::args_os().skip(1));
+    cmd.arg0(bootc_utils::NAME);
     cmd.log_debug();
     Err(anyhow::Error::msg(cmd.exec()).context("execve"))
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -17,6 +17,9 @@ pub mod reexec;
 mod result_ext;
 pub use result_ext::*;
 
+/// The name of our binary
+pub const NAME: &str = "bootc";
+
 /// Intended for use in `main`, calls an inner function and
 /// handles errors by printing them.
 pub fn run_main<F>(f: F)

--- a/crates/utils/src/reexec.rs
+++ b/crates/utils/src/reexec.rs
@@ -36,6 +36,7 @@ pub fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
     };
     cmd.env(k, "1");
     cmd.args(std::env::args_os().skip(1));
+    cmd.arg0(crate::NAME);
     tracing::debug!("Re-executing current process for {k}");
     Err(cmd.exec().into())
 }

--- a/crates/utils/src/tracing_util.rs
+++ b/crates/utils/src/tracing_util.rs
@@ -4,9 +4,9 @@ use tracing_subscriber::prelude::*;
 
 /// Initialize tracing with the default configuration.
 pub fn initialize_tracing() {
-    // Always try to use journald subscriber if we're running under systemd
+    // Always try to use journald subscriber if we're running as root;
     // This ensures key messages (info, warn, error) go to the journal
-    let journald_layer = if let Ok(()) = std::env::var("JOURNAL_STREAM").map(|_| ()) {
+    let journald_layer = if rustix::process::getuid().is_root() {
         tracing_journald::layer()
             .ok()
             .map(|layer| layer.with_filter(tracing_subscriber::filter::LevelFilter::INFO))


### PR DESCRIPTION
I went to look at our journal logging and it didn't do what I expected.

The intention was to always log to the systemd journal,
even if we're spawned directly on the CLI outside of a unit.
