### PR TITLE
ostree: Set parent of merge commit to base commit if present

### DIFF
--- a/crates/ostree-ext/src/container/store.rs
+++ b/crates/ostree-ext/src/container/store.rs
@@ -1167,9 +1167,12 @@ impl ImageImporter {
                     .write_mtree(&mt, cancellable)
                     .context("Writing mtree")?;
                 let merged_root = merged_root.downcast::<ostree::RepoFile>().unwrap();
+                // The merge has the base commit as a parent, if it exists. See
+                // https://github.com/ostreedev/ostree/pull/3523
+                let parent = base_commit.as_deref();
                 let merged_commit = repo
                     .write_commit_with_time(
-                        None,
+                        parent,
                         None,
                         None,
                         Some(&metadata),


### PR DESCRIPTION
Motivated by https://github.com/ostreedev/ostree/pull/3523

This is an obvious and trivially easy thing to do here, and makes dereferencing from "merge -> base" client side also trivial which is especially important in the initramfs.