### PR TITLE
ci: Also validate the composefs-backend feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ validate-rust:
 	cargo test --no-run
 	(cd crates/ostree-ext && cargo check --no-default-features)
 	(cd crates/lib && cargo check --no-default-features)
+	cargo check --features=composefs-backend
 	cargo clippy -- $(CLIPPY_CONFIG)
 	env RUSTDOCFLAGS='-D warnings' cargo doc --lib
 .PHONY: validate-rust

--- a/crates/initramfs/src/lib.rs
+++ b/crates/initramfs/src/lib.rs
@@ -112,7 +112,7 @@ pub fn mount_at_wrapper(
         .with_context(|| format!("Mounting at path {path:?}"))
 }
 
-/// Wrapper around [`rustix::openat`]
+/// Wrapper around [`rustix::fs::openat`]
 #[context("Opening dir {name:?}")]
 pub fn open_dir(dirfd: impl AsFd, name: impl AsRef<Path> + Debug) -> Result<OwnedFd> {
     let res = openat(

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -87,7 +87,9 @@ const SELINUXFS: &str = "/sys/fs/selinux";
 /// The mount path for uefi
 pub(crate) const EFIVARFS: &str = "/sys/firmware/efi/efivars";
 pub(crate) const ARCH_USES_EFI: bool = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"));
+#[cfg(any(feature = "composefs-backend", feature = "install-to-disk"))]
 pub(crate) const ESP_GUID: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+#[cfg(any(feature = "composefs-backend", feature = "install-to-disk"))]
 pub(crate) const DPS_UUID: &str = "6523f8ae-3eb1-4e2a-a05a-18b695ae656f";
 
 const DEFAULT_REPO_CONFIG: &[(&str, &str)] = &[


### PR DESCRIPTION
I was hitting a compliation error which *looks*
like it was actaully an incremental compilation bug? Or it might have been rust-analyzer and local builds fighting over enabled features.

Anyways, this ensures that we're gating on the composefs backend compiling.