### PR TITLE
integration: Copy distro-sync from main Dockerfile

### DIFF
--- a/tests/build.sh
+++ b/tests/build.sh
@@ -34,6 +34,7 @@ case \$ID in
     centos|rhel) dnf config-manager --set-enabled crb;;
     fedora) dnf -y install dnf-utils 'dnf5-command(builddep)';;
 esac
+dnf -y distro-sync ostree{,-libs} systemd
 dnf -y builddep contrib/packaging/bootc.spec
 dnf -y install git-core
 EORUN


### PR DESCRIPTION
Over in https://github.com/bootc-dev/bootc/pull/1607 I actually *just* deduplicated this code, but that isn't ready to merge yet.