### PR TITLE
    generator: Conditionally enable bootc-status units

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,15 @@ RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/rooth
 
 # The final image that derives from the original base and adds the release binaries
 FROM base
-# First, create a layer that is our new binaries.
+RUN <<EORUN
+set -xeuo pipefail
+# Ensure we've flushed out prior state (i.e. files no longer shipped from the old version);
+# and yes, we may need to go to building an RPM in this Dockerfile by default.
+rm -vf /usr/lib/systemd/system/multi-user.target.wants/bootc-*
+EORUN
+# Create a layer that is our new binaries
 COPY --from=build /out/ /
+# We have code in the initramfs so we always need to regenerate it
 RUN <<EORUN
 set -xeuo pipefail
 if test -x /usr/lib/bootc/initramfs-setup; then

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ install:
 	install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man5 target/man/*.5; \
 	install -D -m 0644 -t $(DESTDIR)$(prefix)/share/man/man8 target/man/*.8; \
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/lib/systemd/system systemd/*.service systemd/*.timer systemd/*.path systemd/*.target
-	install -d -m 0755 $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants
-	ln -s ../bootc-status-updated.path $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated.path
-	ln -s ../bootc-status-updated-onboot.target $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-status-updated-onboot.target
 	install -D -m 0644 -t $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/usr/lib/ostree/ baseimage/base/usr/lib/ostree/prepare-root.conf
 	install -d -m 755 $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/sysroot
 	cp -PfT baseimage/base/ostree $(DESTDIR)/$(prefix)/share/doc/bootc/baseimage/base/ostree 
@@ -60,13 +57,6 @@ install:
 	# Copy dracut and systemd config files
 	cp -Prf baseimage/dracut $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
 	cp -Prf baseimage/systemd $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/systemd
-	# Install fedora-bootc-destructive-cleanup in fedora derivatives 
-	ID=$$(. /usr/lib/os-release && echo $$ID); \
-	ID_LIKE=$$(. /usr/lib/os-release && echo $$ID_LIKE); \
-	if [ "$$ID" = "fedora" ] || [[ "$$ID_LIKE" == *"fedora"* ]]; then \
-	ln -s ../bootc-destructive-cleanup.service $(DESTDIR)/$(prefix)/lib/systemd/system/multi-user.target.wants/bootc-destructive-cleanup.service; \
-	install -D -m 0755 -t $(DESTDIR)/$(prefix)/lib/bootc contrib/scripts/fedora-bootc-destructive-cleanup; \
-	fi
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -77,7 +77,7 @@ const RUN_BOOTC: &str = "/run/bootc";
 /// The default path for the host rootfs
 const ALONGSIDE_ROOT_MOUNT: &str = "/target";
 /// Global flag to signal the booted system was provisioned via an alongside bootc install
-const DESTRUCTIVE_CLEANUP: &str = "bootc-destructive-cleanup";
+pub(crate) const DESTRUCTIVE_CLEANUP: &str = "etc/bootc-destructive-cleanup";
 /// This is an ext4 special directory we need to ignore.
 const LOST_AND_FOUND: &str = "lost+found";
 /// The filename of the composefs EROFS superblock; TODO move this into ostree
@@ -1494,7 +1494,7 @@ async fn ostree_install(state: &State, rootfs: &RootSetup, cleanup: Cleanup) -> 
         if matches!(cleanup, Cleanup::TriggerOnNextBoot) {
             let sysroot_dir = crate::utils::sysroot_dir(ostree)?;
             tracing::debug!("Writing {DESTRUCTIVE_CLEANUP}");
-            sysroot_dir.atomic_write(format!("etc/{}", DESTRUCTIVE_CLEANUP), b"")?;
+            sysroot_dir.atomic_write(DESTRUCTIVE_CLEANUP, b"")?;
         }
 
         // We must drop the sysroot here in order to close any open file

--- a/crates/tests-integration/src/system_reinstall.rs
+++ b/crates/tests-integration/src/system_reinstall.rs
@@ -96,7 +96,6 @@ pub(crate) fn run(image: &str, testargs: libtest_mimic::Arguments) -> Result<()>
             let files = [
                 "usr/lib/bootc/fedora-bootc-destructive-cleanup",
                 "usr/lib/systemd/system/bootc-destructive-cleanup.service",
-                "usr/lib/systemd/system/multi-user.target.wants/bootc-destructive-cleanup.service",
                 "etc/tmpfiles.d/bootc-root-ssh.conf",
             ];
 

--- a/systemd/bootc-destructive-cleanup.service
+++ b/systemd/bootc-destructive-cleanup.service
@@ -1,12 +1,10 @@
 [Unit]
 Description=Cleanup previous the installation after an alongside installation
 Documentation=man:bootc(8)
-ConditionPathExists=/sysroot/etc/bootc-destructive-cleanup
 
 [Service]
 Type=oneshot
 ExecStart=/usr/lib/bootc/fedora-bootc-destructive-cleanup
 PrivateMounts=true
 
-[Install]
-WantedBy=multi-user.target
+# No [Install] section, this is enabled via generator

--- a/systemd/bootc-status-updated-onboot.target
+++ b/systemd/bootc-status-updated-onboot.target
@@ -1,7 +1,6 @@
 [Unit]
-Description=Target for bootc status changes on boot
+Description=Bootc status trigger state sync
 Documentation=man:bootc-status-updated.target(8)
-ConditionPathExists=/run/ostree-booted
+After=sysinit.target
 
-[Install]
-WantedBy=multi-user.target
+# No [Install] section, this is enabled via generator

--- a/systemd/bootc-status-updated.path
+++ b/systemd/bootc-status-updated.path
@@ -1,11 +1,9 @@
 [Unit]
 Description=Monitor bootc for status changes
 Documentation=man:bootc-status-updated.path(8)
-ConditionPathExists=/run/ostree-booted
 
 [Path]
 PathChanged=/ostree/bootc
 Unit=bootc-status-updated.target
 
-[Install]
-WantedBy=multi-user.target
+# No [Install] section, this is enabled via generator


### PR DESCRIPTION

    
Right now this service fails in `bcvk run-ephemeral`, but
also likely fails in any non-bootc system that has `subscription-manager`
installed.
    
A problem is that dependencies of units are started even
if the dependee has a condition that disables it.
    
This basically the target and path depend on `/run/ostree-booted`
being present (which yes, won't work for composefs...)
    
Tests: Covered by extant `012-test-unit-status.nu`
   