### PR TITLE
Fixes for rust 1.90

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/bootc-dev/bootc"
 # project isn't actually published as a crate.
 version = "1.8.0"
 # In general we try to keep this pinned to what's in the latest RHEL9.
-# However right now, we bumped to 1.82 as that's what composefs-rs uses.
-rust-version = "1.82.0"
+rust-version = "1.84.0"
 
 include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]
 

--- a/crates/lib/src/fsck.rs
+++ b/crates/lib/src/fsck.rs
@@ -20,7 +20,6 @@ use fn_error_context::context;
 use linkme::distributed_slice;
 use ostree_ext::ostree_prepareroot::Tristate;
 use ostree_ext::{composefs, ostree};
-use serde::{Deserialize, Serialize};
 
 use crate::store::Storage;
 
@@ -120,14 +119,6 @@ fn check_resolvconf(storage: &Storage) -> FsckResult {
         return fsck_err("Found usr/etc/resolv.conf as zero-sized file");
     }
     fsck_ok()
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum VerityState {
-    Enabled,
-    Disabled,
-    Inconsistent((u64, u64)),
 }
 
 #[derive(Debug, Default)]

--- a/crates/lib/src/progress_jsonl.rs
+++ b/crates/lib/src/progress_jsonl.rs
@@ -280,16 +280,9 @@ impl ProgressWriter {
 
 #[cfg(test)]
 mod test {
-    use serde::Deserialize;
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     use super::*;
-
-    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-    struct S {
-        s: String,
-        v: u32,
-    }
 
     #[tokio::test]
     async fn test_jsonl() -> Result<()> {

--- a/crates/ostree-ext/src/generic_decompress.rs
+++ b/crates/ostree-ext/src/generic_decompress.rs
@@ -24,7 +24,7 @@ const DOCKER_TYPE_LAYER_TAR: &str = "application/vnd.docker.image.rootfs.diff.ta
 
 /// Extends the `Read` trait with another method to get mutable access to the inner reader
 trait ReadWithGetInnerMut: Read + Send + 'static {
-    fn get_inner_mut(&mut self) -> &mut (dyn Read);
+    fn get_inner_mut(&mut self) -> &mut dyn Read;
 }
 
 // TransparentDecompressor
@@ -38,7 +38,7 @@ impl<R: Read + Send + 'static> Read for TransparentDecompressor<R> {
 }
 
 impl<R: Read + Send + 'static> ReadWithGetInnerMut for TransparentDecompressor<R> {
-    fn get_inner_mut(&mut self) -> &mut (dyn Read) {
+    fn get_inner_mut(&mut self) -> &mut dyn Read {
         &mut self.0
     }
 }
@@ -54,7 +54,7 @@ impl<R: std::io::BufRead + Send + 'static> Read for GzipDecompressor<R> {
 }
 
 impl<R: std::io::BufRead + Send + 'static> ReadWithGetInnerMut for GzipDecompressor<R> {
-    fn get_inner_mut(&mut self) -> &mut (dyn Read) {
+    fn get_inner_mut(&mut self) -> &mut dyn Read {
         self.0.get_mut()
     }
 }
@@ -72,7 +72,7 @@ impl<'a: 'static, R: std::io::BufRead + Send + 'static> Read for ZstdDecompresso
 impl<'a: 'static, R: std::io::BufRead + Send + 'static> ReadWithGetInnerMut
     for ZstdDecompressor<'a, R>
 {
-    fn get_inner_mut(&mut self) -> &mut (dyn Read) {
+    fn get_inner_mut(&mut self) -> &mut dyn Read {
         self.0.get_mut()
     }
 }


### PR DESCRIPTION
- **rust-1.90: Fix warnings on unnecessary parentheses**
- **rust-1.90: Remove newly-detected dead code**
- **rust-1.90: Update MSRV to 1.84.0**

Closes: https://github.com/bootc-dev/bootc/issues/1605