### PR TITLE
ci: Drop control/skip-ci

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,13 +4,6 @@ documentation:
     - 'docs/**'
     - README.md
 
-# Automatically bypass most CI for doc-only changes
-control/skip-ci:
-- changed-files:
-  - any-glob-to-all-files:
-    - 'docs/**'
-    - README.md
-
 area/install:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   tests:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
@@ -43,7 +42,6 @@ jobs:
       - name: Clippy (gate on correctness and suspicous)
         run: make validate-rust
   fedora-container-tests:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Get a newer podman for heredoc support (from debian testing)
@@ -58,7 +56,6 @@ jobs:
       - name: Build and run container integration tests
         run: sudo just run-container-integration run-container-external-tests
   container-continuous:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Get a newer podman for heredoc support (from debian testing)
@@ -81,7 +78,6 @@ jobs:
         log-level: warn
         command: check -A duplicate bans sources licenses
   install-tests:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'control/skip-ci') }}
     name: "Test install"
     # For a not-ancient podman
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This burned us recently. Since our man pages are input to the build, we can't really skip CI for them.