### PR TITLE
build-sys: Various cleanups, doc clarification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,19 @@
-# The big one - this can get HUGE and we don't want
-# to copy it around.
-target
-# This one can have large .qcow2 files written by coreos-assembler
-.cosa
-# TMT interprets these, not the container build
-plans/
-# These only affect flow outside of the container
-Dockerfile
-Justfile
-hack/Containerfile
+# Exclude everything by default, then include just what we need
+# Especially note this means that .git is not included, and not tests/
+# to avoid spurious rebuilds.
+*
+
+# This one signals we're in a bootc toplevel
+!ADOPTERS.md
+# Toplevel build bits
+!Makefile
+!Cargo.*
+# We do build manpages from markdown
+!docs/
+# We use the spec file
+!contrib/
+# The systemd units and baseimage bits end up in installs
+!systemd/
+!baseimage/
+# And finally of course all the Rust sources
+!crates/

--- a/Justfile
+++ b/Justfile
@@ -1,10 +1,18 @@
-# Build the container image from current sources
+# The default entrypoint to working on this project.
+# Commands here typically wrap e.g. `podman build` or
+# other tools which might launch e.g. VMs.
+# 
+# See also `Makefile`.
+
+# Build the container image from current sources.
+# Note commonly you might want to override the base image via e.g.
+# `just build --build-arg=base=quay.io/fedora/fedora-bootc:42`
 build *ARGS:
     podman build --jobs=4 -t localhost/bootc {{ARGS}} .
 
 # This container image has additional testing content and utilities
 build-integration-test-image *ARGS:
-    podman build --jobs=4 -t localhost/bootc-integration -f hack/Containerfile {{ARGS}} .
+    cd hack && podman build --jobs=4 -t localhost/bootc-integration -f Containerfile {{ARGS}} .
     # Keep these in sync with what's used in hack/lbi
     podman pull -q --retry 5 --retry-delay 5s quay.io/curl/curl:latest quay.io/curl/curl-base:latest registry.access.redhat.com/ubi9/podman:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+# Understanding Makefile vs Justfile:
+#
+# This file MUST NOT:
+# - Spawn podman or virtualization tools
+# - Invoke `sudo`
+#
+# Stated positively, the code invoked from here is only expected to
+# operate as part of "a build" that results in a bootc binary
+# plus data files. The two key operations are `make`
+# and `make install`.
+# We expect code run from here is inside a container with low
+# privileges - running as a nonzero UID even.
+
 prefix ?= /usr
 
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
@@ -78,9 +91,6 @@ bin-archive: all
 
 test-bin-archive: all
 	$(MAKE) install-all DESTDIR=tmp-install && $(TAR_REPRODUCIBLE) --zstd -C tmp-install -cf target/bootc.tar.zst . && rm tmp-install -rf
-
-test:
-	tests/build.sh && tests/test.sh
 
 # This gates CI by default. Note that for clippy, we gate on
 # only the clippy correctness and suspicious lints, plus a select

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -5,18 +5,24 @@
 
 FROM scratch as context
 # We only need this stuff in the initial context
-COPY hack /hack
-COPY contrib /contrib
+COPY . /
 
-FROM localhost/bootc
+# An intermediate layer which caches the extended RPMS
+FROM localhost/bootc as extended
 # We support e.g. adding cloud-init
 ARG variant=
 # And this layer has additional stuff for testing, such as nushell etc.
 RUN --mount=type=bind,from=context,target=/run/context <<EORUN
 set -xeuo pipefail
-cd /run/context/hack
+cd /run/context/
 ./provision-derived.sh "$variant"
+EORUN
 
+# And the configs
+FROM extended
+RUN --mount=type=bind,from=context,target=/run/context <<EORUN
+set -xeuo pipefail
+cd /run/context
 # For test-22-logically-bound-install
 cp -a lbi/usr/. /usr
 for x in curl.container curl-base.image podman.image; do
@@ -24,9 +30,9 @@ for x in curl.container curl-base.image podman.image; do
 done
 
 # Add some testing kargs into our dev builds
-install -D -t /usr/lib/bootc/kargs.d /run/context/hack/test-kargs/*
+install -D -t /usr/lib/bootc/kargs.d test-kargs/*
 # Also copy in some default install configs we use for testing
-install -D -t /usr/lib/bootc/install/ /run/context/hack/install-test-configs/*
+install -D -t /usr/lib/bootc/install/ install-test-configs/*
 # Finally, test our own linting
 bootc container lint --fatal-warnings
 EORUN


### PR DESCRIPTION
First change `.dockerignore` to be an allowlist.
This avoids spurious rebuilds when touching e.g. `tmt/`, and also crucially we don't leak `.git/` into the sources which can easily change as one makes commits/branches.
This also requires touching the `hack/` directory which is now fully self contained.

While we're here, make clear the roles of Justfile vs Makefile. Remove the `make test`.