### PR TITLE
 tests: add custom selinux policy test

### DIFF
--- a/tmt/plans/integration.fmf
+++ b/tmt/plans/integration.fmf
@@ -60,3 +60,11 @@ execute:
     how: fmf
     test:
         - /tmt/tests/test-26-examples-build
+
+/test-27-custom-selinux-policy:
+  summary: Execute restorecon test on system with custom selinux policy
+  discover:
+    how: fmf
+    test:
+        - /tmt/tests/bootc-install-provision
+        - /tmt/tests/test-27-custom-selinux-policy

--- a/tmt/tests/booted/test-custom-selinux-policy.nu
+++ b/tmt/tests/booted/test-custom-selinux-policy.nu
@@ -1,0 +1,63 @@
+# Verify that correct labels are applied after a deployment
+use std assert
+use tap.nu
+
+# This code runs on *each* boot.
+# Here we just capture information.
+bootc status
+
+# Run on the first boot
+def initial_build [] {
+    tap begin "local image push + pull + upgrade"
+
+    let td = mktemp -d
+    cd $td
+
+    bootc image copy-to-storage
+
+    # A simple derived container that customizes selinux policy for random dir
+    "FROM localhost/bootc
+RUN mkdir /opt123; echo \"/opt123 /opt\" >> /etc/selinux/targeted/contexts/files/file_contexts.subs_dist
+" | save Dockerfile
+    # Build it
+    podman build -t localhost/bootc-derived .
+
+    bootc switch --soft-reboot=auto --transport containers-storage localhost/bootc-derived
+    
+    assert (not ("/opt123" | path exists))
+
+    # https://tmt.readthedocs.io/en/stable/stories/features.html#reboot-during-test
+    tmt-reboot
+}
+
+# The second boot; verify we're in the derived image and directory has correct selinux label
+def second_boot [] {
+    tap begin "Verify directory exists and has correct SELinux label"
+
+    assert ("/opt123" | path exists)
+
+    # Verify the directories have the correct SELinux labels
+    let opt123_label = (^stat --format=%C /opt123 | str trim)
+    let opt_label = (^stat --format=%C /opt | str trim)
+
+    print $"opt123 SELinux label: ($opt123_label)"
+    print $"opt SELinux label: ($opt_label)"
+
+    # Both should have the same label (system_u:object_r:usr_t:s0)
+    assert ($opt123_label | str contains "system_u:object_r:usr_t:s0") $"Expected system_u:object_r:usr_t:s0 label for /opt123, got: ($opt123_label)"
+    assert ($opt_label | str contains "system_u:object_r:usr_t:s0") $"Expected system_u:object_r:usr_t:s0 label for /opt, got: ($opt_label)"
+
+    # Verify both labels are the same
+    assert ($opt123_label == $opt_label) $"Labels should be the same: opt123=($opt123_label) vs opt=($opt_label)"
+
+    tap ok
+}
+
+def main [] {
+    # See https://tmt.readthedocs.io/en/stable/stories/features.html#reboot-during-test
+    match $env.TMT_REBOOT_COUNT? {
+        null | "0" => initial_build,
+        "1" => second_boot,
+        $o => { error make { msg: $"Invalid TMT_REBOOT_COUNT ($o)" } },
+    }
+}

--- a/tmt/tests/test-27-custom-selinux-policy.fmf
+++ b/tmt/tests/test-27-custom-selinux-policy.fmf
@@ -1,0 +1,3 @@
+summary: Execute custom selinux policy test
+test: nu booted/test-custom-selinux-policy.nu
+duration: 30m


### PR DESCRIPTION
Ensure that if a custom policy is added in a
Containerfile, the resulting deployment has the expected
labels as well.