### PR TITLE
Updates to build sys and CONTRIBUTING.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,30 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install deps
-        run: ./ci/installdeps.sh
-      - name: Mark git checkout as safe
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      # xref containers/containers-image-proxy-rs
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "tests"
-      - name: make validate-rust
-        # the ruff checks are covered via a dedicated action
-        run: make validate-rust
-      - name: Run tests
-        run: cargo test -- --nocapture --quiet
-      - name: Manpage generation
-        run: cargo xtask update-generated
-      - name: Clippy (gate on correctness and suspicous)
-        run: make validate-rust
-  fedora-container-tests:
+  # Wrapper for validation
+  validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Get a newer podman for heredoc support (from debian testing)
@@ -49,14 +27,12 @@ jobs:
           set -eux
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
           sudo apt update
-          sudo apt install -y crun/testing podman/testing skopeo/testing
-      - name: Installdeps
-        run: sudo apt update && sudo apt install just
+          sudo apt install -y crun/testing podman/testing skopeo/testing just
       - uses: actions/checkout@v4
-      - name: Build and run container integration tests
-        run: |
-          sudo just build
-          sudo just run-container-integration run-container-external-tests
+      - name: Free up disk space on runner
+        run: sudo ./ci/clean-gha-runner.sh
+      - name: Validate (default)
+        run: just validate
   container-continuous:
     runs-on: ubuntu-24.04
     steps:
@@ -65,10 +41,12 @@ jobs:
           set -eux
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
           sudo apt update
-          sudo apt install -y crun/testing podman/testing skopeo/testing
+          sudo apt install -y crun/testing podman/testing skopeo/testing just
       - name: Installdeps
         run: sudo apt update && sudo apt install just
       - uses: actions/checkout@v4
+      - name: Free up disk space on runner
+        run: sudo ./ci/clean-gha-runner.sh
       - name: Build with continuous repo enabled
         run: sudo just build --build-arg=continuous_repo=1
   cargo-deny:
@@ -89,7 +67,7 @@ jobs:
           set -eux
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
           sudo apt update
-          sudo apt install -y crun/testing podman/testing skopeo/testing
+          sudo apt install -y crun/testing podman/testing skopeo/testing just
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Free up disk space on runner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Free up disk space on runner
+        run: sudo ./ci/clean-gha-runner.sh
+
       - name: Set architecture variable
         id: set_arch
         run: echo "ARCH=$(arch)" >> $GITHUB_ENV
@@ -37,6 +40,10 @@ jobs:
       - name: Build container and disk image
         run: |
           sudo tests/build.sh ${{ matrix.test_os }}
+
+      - name: Run container tests
+        run:
+          sudo just test-container
 
       - name: Archive disk image
         uses: actions/upload-artifact@v4
@@ -52,10 +59,13 @@ jobs:
       matrix:
         test_os: [fedora-42, fedora-43, centos-9, centos-10]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free up disk space on runner
+        run: sudo ./ci/clean-gha-runner.sh
 
       - name: Set architecture variable
         id: set_arch
@@ -65,7 +75,7 @@ jobs:
         run: |
           sudo apt-get update
           # see https://tmt.readthedocs.io/en/stable/overview.html#install
-          sudo apt install -y libkrb5-dev pkg-config libvirt-dev genisoimage qemu-kvm qemu-utils libvirt-daemon-system
+          sudo apt install -y libkrb5-dev pkg-config libvirt-dev genisoimage qemu-kvm qemu-utils libvirt-daemon-system just
           pip install --user "tmt[provision-virtual]"
 
       - name: Create folder to save disk image
@@ -87,9 +97,9 @@ jobs:
       - name: Workaround https://github.com/teemtee/testcloud/issues/18
         run: sudo rm -f /usr/bin/chcon && sudo ln -sr /usr/bin/true /usr/bin/chcon
 
-      - name: Run test
+      - name: Run all TMT tests
         run: |
-          tests/run-tmt.sh
+          just test-tmt-nobuild
 
       - name: Archive TMT logs
         if: always()

--- a/contrib/packaging/fedora-extra.txt
+++ b/contrib/packaging/fedora-extra.txt
@@ -1,0 +1,7 @@
+# Extra packages needed in the build container for Fedora derivatives
+# that aren't actually used to build the code necessarily, but
+# are used by targets in the Dockerfile.
+rustfmt
+clippy
+git-core
+jq

--- a/crates/etc-merge/src/lib.rs
+++ b/crates/etc-merge/src/lib.rs
@@ -418,12 +418,11 @@ fn collect_xattrs(etc_fd: &CapStdDir, rel_path: impl AsRef<Path>) -> anyhow::Res
 }
 
 #[context("Copying xattrs")]
-fn copy_xattrs(xattrs: &Xattrs, new_etc_fd: &CapStdDir, file: &PathBuf) -> anyhow::Result<()> {
+fn copy_xattrs(xattrs: &Xattrs, new_etc_fd: &CapStdDir, path: &Path) -> anyhow::Result<()> {
     for (attr, value) in xattrs.borrow().iter() {
-        let path = Path::new(&format!("/proc/self/fd/{}", new_etc_fd.as_raw_fd())).join(file);
-
-        lsetxattr(path, attr.as_ref(), value, XattrFlags::empty())
-            .context(format!("setxattr for {file:?}"))?;
+        let fdpath = &Path::new(&format!("/proc/self/fd/{}", new_etc_fd.as_raw_fd())).join(path);
+        lsetxattr(fdpath, attr.as_ref(), value, XattrFlags::empty())
+            .with_context(|| format!("setxattr {attr:?} for {fdpath:?}"))?;
     }
 
     Ok(())

--- a/crates/xtask/src/xtask.rs
+++ b/crates/xtask/src/xtask.rs
@@ -1,5 +1,8 @@
 //! See https://github.com/matklad/cargo-xtask
-//! This is kind of like "Justfile but in Rust".
+//! This project now has a Justfile and a Makefile.
+//! Commands here are not always intended to be run directly
+//! by the user - add commands here which otherwise might
+//! end up as a lot of nontrivial bash code.
 
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};


### PR DESCRIPTION
The emphasis here is on trying to have
the `Justfile` be the default entrypoint,
wrapping other tools.

- Replace mentions of podman-bootc with bcvk
  since I hope the latter supercedes the former
- Unify the unit test entrypoint
- Set up /var/tmp as a tmpdir to fix the etc merge
  test (otherwise, selinux failures w/tmp)
- Run the unit+container tests in integration.yml
- Have `just validate` run in a container

Signed-off-by: Colin Walters <walters@verbum.org>
Closes: https://github.com/bootc-dev/bootc/issues/1635