### PR TITLE
docs: Adding a private OCI registry section

### DIFF
--- a/docs/src/registries-and-offline.md
+++ b/docs/src/registries-and-offline.md
@@ -21,6 +21,14 @@ insecure=true
 
 For more, see [containers-registries.conf](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md).
 
+## Private registries
+
+It's common to use a private repository when deploying a fleet of bootc instances.
+
+In addition to registry configuration, if you want to use a private registry, you'll need to address authentication. Place a `auth.json` file in the directory `/etc/ostree/auth.json`.
+
+For more, see [auth.json](https://man.archlinux.org/man/containers-auth.json.5)
+
 ## Disconnected and offline updates
 
 It is common (a best practice even) to maintain systems which default

--- a/docs/src/registries-and-offline.md
+++ b/docs/src/registries-and-offline.md
@@ -25,7 +25,7 @@ For more, see [containers-registries.conf](https://github.com/containers/image/b
 
 It's common to use a private repository when deploying a fleet of bootc instances.
 
-In addition to registry configuration, if you want to use a private registry, you'll need to address authentication. Place a `auth.json` file in the directory `/etc/ostree/auth.json`.
+In addition to registry configuration, private registries require authentication. This is configured by placing an `auth.json` file at `/etc/ostree/auth.json`.
 
 For more, see [auth.json](https://man.archlinux.org/man/containers-auth.json.5)
 


### PR DESCRIPTION
Changes made:

I create a private registry section to explain where to add `auth.json` file for OCI auth 