### PR TITLE
system-reinstall-bootc: Handle --help

### DIFF
--- a/crates/system-reinstall-bootc/src/config/mod.rs
+++ b/crates/system-reinstall-bootc/src/config/mod.rs
@@ -1,52 +1,31 @@
-use anyhow::{ensure, Context, Result};
-use clap::Parser;
+use std::{fs::File, io::BufReader};
+
+use anyhow::{Context, Result};
+use bootc_utils::PathQuotedDisplay;
 use serde::{Deserialize, Serialize};
 
 mod cli;
+
+/// The environment variable that can be used to specify an image.
+const CONFIG_VAR: &str = "BOOTC_REINSTALL_CONFIG";
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReinstallConfig {
     /// The bootc image to install on the system.
     pub(crate) bootc_image: String,
-
-    /// The raw CLI arguments that were used to invoke the program. None if the config was loaded
-    /// from a file.
-    #[serde(skip_deserializing)]
-    cli_flags: Option<Vec<String>>,
 }
 
 impl ReinstallConfig {
-    pub fn parse_from_cli(cli: cli::Cli) -> Self {
-        Self {
-            bootc_image: cli.bootc_image,
-            cli_flags: Some(std::env::args().collect::<Vec<String>>()),
-        }
+    pub fn load() -> Result<Option<Self>> {
+        let Some(config) = std::env::var_os(CONFIG_VAR) else {
+            return Ok(None);
+        };
+        let f = File::open(&config)
+            .with_context(|| format!("Opening {}", PathQuotedDisplay::new(&config)))
+            .map(BufReader::new)?;
+        let r = serde_yaml::from_reader(f)
+            .with_context(|| format!("Parsing config from {}", PathQuotedDisplay::new(&config)))?;
+        Ok(Some(r))
     }
-
-    pub fn load() -> Result<Self> {
-        Ok(match std::env::var("BOOTC_REINSTALL_CONFIG") {
-            Ok(config_path) => {
-                ensure_no_cli_args()?;
-
-                serde_yaml::from_slice(
-                    &std::fs::read(&config_path)
-                        .context("reading BOOTC_REINSTALL_CONFIG file {config_path}")?,
-                )
-                .context("parsing BOOTC_REINSTALL_CONFIG file {config_path}")?
-            }
-            Err(_) => ReinstallConfig::parse_from_cli(cli::Cli::parse()),
-        })
-    }
-}
-
-fn ensure_no_cli_args() -> Result<()> {
-    let num_args = std::env::args().len();
-
-    ensure!(
-        num_args == 1,
-        "BOOTC_REINSTALL_CONFIG is set, but there are {num_args} CLI arguments. BOOTC_REINSTALL_CONFIG is meant to be used with no arguments."
-    );
-
-    Ok(())
 }

--- a/crates/tests-integration/src/container.rs
+++ b/crates/tests-integration/src/container.rs
@@ -39,6 +39,16 @@ pub(crate) fn test_bootc_install_config() -> Result<()> {
     drop(config);
     Ok(())
 }
+
+/// Previously system-reinstall-bootc bombed out when run as non-root even if passing --help
+fn test_system_reinstall_help() -> Result<()> {
+    let o = Command::new("runuser")
+        .args(["-u", "bin", "system-reinstall-bootc", "--help"])
+        .output()?;
+    assert!(o.status.success());
+    Ok(())
+}
+
 /// Tests that should be run in a default container image.
 #[context("Container tests")]
 pub(crate) fn run(testargs: libtest_mimic::Arguments) -> Result<()> {
@@ -46,6 +56,7 @@ pub(crate) fn run(testargs: libtest_mimic::Arguments) -> Result<()> {
         new_test("bootc upgrade", test_bootc_upgrade),
         new_test("install config", test_bootc_install_config),
         new_test("status", test_bootc_status),
+        new_test("system-reinstall --help", test_system_reinstall_help),
     ];
 
     libtest_mimic::run(&testargs, tests.into()).exit()


### PR DESCRIPTION
I wanted to add a CLI option here to avoid the reboot, and ran into the fact that our option parsing was suboptimal to start with.

We never documented `BOOTC_REINSTALL_CONFIG` at all...I'm kind of tempted to deprecate it.