### PR TITLE
spec: Provide ostree-ext on rhel9

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -1,5 +1,5 @@
 %bcond_without check
-%if 0%{?rhel} >= 10 || 0%{?fedora} > 41
+%if 0%{?rhel} >= 9 || 0%{?fedora} > 41
     %bcond_without ostree_ext
 %else
     %bcond_with ostree_ext


### PR DESCRIPTION
This landed downstream in https://gitlab.com/redhat/centos-stream/rpms/bootc/-/commit/3d4f302c504e565f53a65ecbc7bdaa23c25c2316 but some CI flows build from this spec, so do the change here too.