### PR TITLE
system-reinstall-bootc: Do not warn on unmounted LVM volumes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "dialoguer",
+ "fn-error-context",
  "indoc",
  "log",
  "openssh-keys",

--- a/crates/system-reinstall-bootc/Cargo.toml
+++ b/crates/system-reinstall-bootc/Cargo.toml
@@ -22,6 +22,7 @@ bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "
 anstream = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+fn-error-context = { workspace = true }
 indoc = { workspace = true }
 log = { workspace = true }
 rustix = { workspace = true }

--- a/crates/system-reinstall-bootc/src/btrfs.rs
+++ b/crates/system-reinstall-bootc/src/btrfs.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use bootc_mount::Filesystem;
+use fn_error_context::context;
 
+#[context("check_root_siblings")]
 pub(crate) fn check_root_siblings() -> Result<Vec<String>> {
     let mounts = bootc_mount::run_findmnt(&[], None)?;
     let problem_filesystems: Vec<String> = mounts

--- a/crates/system-reinstall-bootc/src/config/mod.rs
+++ b/crates/system-reinstall-bootc/src/config/mod.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::BufReader};
 
 use anyhow::{Context, Result};
 use bootc_utils::PathQuotedDisplay;
+use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 
 mod cli;
@@ -17,6 +18,7 @@ pub(crate) struct ReinstallConfig {
 }
 
 impl ReinstallConfig {
+    #[context("load")]
     pub fn load() -> Result<Option<Self>> {
         let Some(config) = std::env::var_os(CONFIG_VAR) else {
             return Ok(None);

--- a/crates/system-reinstall-bootc/src/lvm.rs
+++ b/crates/system-reinstall-bootc/src/lvm.rs
@@ -26,7 +26,7 @@ pub(crate) struct LogicalVolume {
 
 #[context("parse_volumes")]
 pub(crate) fn parse_volumes(group: Option<&str>) -> Result<Vec<LogicalVolume>> {
-    if which::which("podman").is_err() {
+    if which::which("lvs").is_err() {
         tracing::debug!("lvs binary not found. Skipping logical volume check.");
         return Ok(Vec::<LogicalVolume>::new());
     }

--- a/crates/system-reinstall-bootc/src/lvm.rs
+++ b/crates/system-reinstall-bootc/src/lvm.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 use anyhow::Result;
 use bootc_mount::run_findmnt;
 use bootc_utils::{CommandRunExt, ResultExt};
+use fn_error_context::context;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -23,6 +24,7 @@ pub(crate) struct LogicalVolume {
     vg_name: String,
 }
 
+#[context("parse_volumes")]
 pub(crate) fn parse_volumes(group: Option<&str>) -> Result<Vec<LogicalVolume>> {
     if which::which("podman").is_err() {
         tracing::debug!("lvs binary not found. Skipping logical volume check.");
@@ -46,6 +48,7 @@ pub(crate) fn parse_volumes(group: Option<&str>) -> Result<Vec<LogicalVolume>> {
         .collect())
 }
 
+#[context("check_root_siblings")]
 pub(crate) fn check_root_siblings() -> Result<Vec<String>> {
     let all_volumes = parse_volumes(None)?;
 

--- a/crates/system-reinstall-bootc/src/main.rs
+++ b/crates/system-reinstall-bootc/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::{ensure, Context, Result};
 use bootc_utils::CommandRunExt;
 use clap::Parser;
+use fn_error_context::context;
 use rustix::process::getuid;
 
 mod btrfs;
@@ -29,6 +30,7 @@ struct Opts {
     // Note if we ever add any other options here,
 }
 
+#[context("run")]
 fn run() -> Result<()> {
     // We historically supported an environment variable providing a config to override the image, so
     // keep supporting that. I'm considering deprecating that though.

--- a/crates/system-reinstall-bootc/src/podman.rs
+++ b/crates/system-reinstall-bootc/src/podman.rs
@@ -3,9 +3,11 @@ use crate::prompt;
 use super::ROOT_KEY_MOUNT_POINT;
 use anyhow::{ensure, Context, Result};
 use bootc_utils::CommandRunExt;
+use fn_error_context::context;
 use std::process::Command;
 use which::which;
 
+#[context("bootc_has_clean")]
 fn bootc_has_clean(image: &str) -> Result<bool> {
     let output = Command::new("podman")
         .args([
@@ -22,6 +24,7 @@ fn bootc_has_clean(image: &str) -> Result<bool> {
     Ok(stdout_str.contains("--cleanup"))
 }
 
+#[context("reinstall_command")]
 pub(crate) fn reinstall_command(image: &str, ssh_key_file: &str) -> Result<Command> {
     let mut podman_command_and_args = [
         // We use podman to run the bootc container. This might change in the future to remove the
@@ -108,6 +111,7 @@ fn image_exists_command(image: &str) -> Command {
     command
 }
 
+#[context("pull_if_not_present")]
 pub(crate) fn pull_if_not_present(image: &str) -> Result<()> {
     let result = image_exists_command(image).status()?;
 
@@ -136,6 +140,7 @@ const fn podman_install_script_path() -> &'static str {
     }
 }
 
+#[context("ensure_podman_installed")]
 pub(crate) fn ensure_podman_installed() -> Result<()> {
     if which("podman").is_ok() {
         return Ok(());


### PR DESCRIPTION
If the system has a swap partition (or any other volume which is not
currently mounted) the `findmnt` command will (expectedly) fail to
find it.  Don't early exit in this case, instead just ignore that
volume.  If it wasn't mounted in the first place, we don't need to
warn about it being unmounted after the reinstall operation is
complete.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
Closes: #1659
