### PR TITLE
install: Add a tmpfs for /var/lib/containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           df -h /
           # The ostree-container tests
           sudo podman run --privileged --pid=host -v /:/run/host -v $(pwd):/src:ro -v /var/tmp:/var/tmp \
+            --tmpfs /var/lib/containers \
             -v /run/dbus:/run/dbus -v /run/systemd:/run/systemd localhost/bootc /src/crates/ostree-ext/ci/priv-integration.sh
           # Nondestructive but privileged tests
           sudo bootc-integration-tests host-privileged localhost/bootc-integration-install


### PR DESCRIPTION
Recent podman versions got stricter about not doing overlay-on-overlay by default.