### PR TITLE
test: Use SRPM as test code source to work with gating test

### DIFF
--- a/hack/Containerfile.packit
+++ b/hack/Containerfile.packit
@@ -12,6 +12,7 @@ COPY ARTIFACTS /var/ARTIFACTS
 # Copy bootc repo
 COPY test-artifacts /var/share/test-artifacts
 
+ARG GATING
 RUN <<EORUN
 set -xeuo pipefail
 . /usr/lib/os-release
@@ -21,6 +22,12 @@ fi
 cp test-artifacts.repo /etc/yum.repos.d/
 dnf -y update bootc
 ./provision-derived.sh
+
+if [[ "$GATING" == true ]]; then
+    # Install Fedora CI/OSCI required packages for "Prepare dist-git sources" task
+    dnf install -y  rpm-build @buildsys-build 'dnf-command(builddep)'
+    dnf builddep -y /var/share/test-artifacts/*.src.rpm
+fi
 
 # For test-22-logically-bound-install
 cp -a lbi/usr/. /usr

--- a/hack/packit-reboot.yml
+++ b/hack/packit-reboot.yml
@@ -5,14 +5,8 @@
 - name: Reboot after system-reinstall-bootc
   hosts: all
   tasks:
-    - name: Check system mode
-      shell: bootc status --json | jq -r '.status.type'
-      register: os_mode
-
-    # null type means package mode
     - name: Reboot system to image mode
       reboot:
-      when: os_mode.stdout == 'null'
 
     - name: Wait for connection to become reachable/usable
       wait_for_connection:

--- a/tests/run-tmt.sh
+++ b/tests/run-tmt.sh
@@ -23,4 +23,5 @@ rm -vrf /var/tmp/tmt/testcloud/images/bootc-integration-test.qcow2
 
 cd target/tmt-workdir
 # TMT will rsync tmt-* scripts to TMT_SCRIPTS_DIR=/var/lib/tmt/scripts
-exec tmt --context "test_disk_image=${DISK}" run --all -e TMT_SCRIPTS_DIR=/var/lib/tmt/scripts "$@"
+# running_env=image_mode means running tmt on image mode system on Github CI or locally
+exec tmt --context "test_disk_image=${DISK}" --context "running_env=image_mode" run --all -e TMT_SCRIPTS_DIR=/var/lib/tmt/scripts "$@"

--- a/tmt/plans/integration.fmf
+++ b/tmt/plans/integration.fmf
@@ -2,16 +2,32 @@ provision:
   how: virtual
   image: $@{test_disk_image}
 prepare:
-  # Replace package mode with image mode
+  # Install image mode system on package mode system
+  # Do not run on image mode VM running on Github CI and Locally
+  # Run on package mode VM running on Packit and Gating
+  - how: install
+    package:
+      - podman
+      - skopeo
+      - jq
+      - bootc
+      - system-reinstall-bootc
+      - expect
+      - ansible-core
+      - zstd
+    when: running_env != image_mode
   - how: shell
     script:
-      - pwd && ls -al
-      - if [[ -d hack ]]; then cd hack && ./provision-packit.sh; fi
+      - mkdir -p bootc && cp /var/share/test-artifacts/*.src.rpm bootc
+      - cd bootc && rpm2cpio *.src.rpm | cpio -idmv && rm -f *-vendor.tar.zstd && zstd -d *.tar.zstd && tar -xvf *.tar -C . --strip-components=1 && ls -al
+      - pwd && ls -al && cd bootc/hack && ./provision-packit.sh
+    when: running_env != image_mode
   # tmt-reboot and reboot do not work in this case
   # reboot in ansible is the only way to reboot in tmt prepare
   - how: ansible
     playbook:
       - https://github.com/bootc-dev/bootc/raw/refs/heads/main/hack/packit-reboot.yml
+    when: running_env != image_mode
 execute:
   how: tmt
 
@@ -71,7 +87,7 @@ execute:
     test:
         - /tmt/tests/test-26-examples-build
   adjust:
-    - when: running_env == packit
+    - when: running_env != image_mode
       enabled: false
       because: packit tests use RPM bootc and does not install /usr/lib/bootc/initramfs-setup
 
@@ -82,6 +98,6 @@ execute:
     test:
         - /tmt/tests/test-27-custom-selinux-policy
   adjust:
-    - when: running_env == packit
+    - when: running_env != image_mode
       enabled: false
       because: tmt-reboot does not work with systemd reboot in testing farm environment


### PR DESCRIPTION
In Fedora or OSCI dist-git gating, SRPM is the only way to get test code. Change to extracting SRPM to get source code. That works with both Packit and dist-git gating.

This PR also includes a `when: running_env != unify` in prepare to make it only runs on Packit or dist-git gating test. In our case, `unify` means running on Github CI or locally.