### PR TITLE
dockerignore: Workaround for podman bug with secrets + remote

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,8 @@
 # The systemd units and baseimage bits end up in installs
 !systemd/
 !baseimage/
+# Workaround for podman bug with secrets + remote
+# https://github.com/containers/podman/issues/25314
+!podman-build-secret*
 # And finally of course all the Rust sources
 !crates/


### PR DESCRIPTION
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
