### PR TITLE
ci: Use bcvk

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -65,5 +65,20 @@ runs:
       if: ${{ inputs.libvirt == 'true' }}
       shell: bash
       run: |
-        set -eux
-        sudo apt install -y libkrb5-dev pkg-config libvirt-dev genisoimage qemu-utils qemu-kvm qemu-utils libvirt-daemon-system
+        set -xeuo pipefail
+        export BCVK_VERSION=0.5.3
+        sudo apt install -y libkrb5-dev pkg-config libvirt-dev genisoimage qemu-utils qemu-kvm virtiofsd libvirt-daemon-system
+        # Something in the stack is overriding this, but we want session right now for bcvk
+        echo LIBVIRT_DEFAULT_URI=qemu:///session >> $GITHUB_ENV
+        td=$(mktemp -d)
+        cd $td
+        # Install bcvk
+        target=bcvk-$(arch)-unknown-linux-gnu
+        curl -LO https://github.com/bootc-dev/bcvk/releases/download/v${BCVK_VERSION}/${target}.tar.gz
+        tar xzf ${target}.tar.gz
+        sudo install -T ${target} /usr/bin/bcvk
+        cd -
+        rm -rf "$td"
+
+        # Also bump the default fd limit as a workaround for https://github.com/bootc-dev/bcvk/issues/65
+        sudo sed -i -e 's,^\* hard nofile 65536,* hard nofile 524288,' /etc/security/limits.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Something seems to be setting this in the default GHA runners, which breaks bcvk
+  # as the default runner user doesn't have access
+  LIBVIRT_DEFAULT_URI: "qemu:///session"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -135,11 +138,11 @@ jobs:
 
       - name: Build container and disk image
         run: |
-          sudo tests/build.sh ${{ matrix.test_os }}
+          tests/build.sh ${{ matrix.test_os }}
 
       - name: Run container tests
         run:
-          sudo just test-container
+          just test-container
 
       - name: Archive disk image
         uses: actions/upload-artifact@v4

--- a/Justfile
+++ b/Justfile
@@ -24,38 +24,7 @@ build-install-test-image: build-integration-test-image
     cd hack && podman build -t localhost/bootc-integration-install -f Containerfile.drop-lbis
 
 build-disk-image container target:
-    #!/bin/bash
-    set -xeuo pipefail
-    SIZE=20G
-    bcvk=$(which bcvk 2>/dev/null || true)
-    if test -z "${bcvk}" && test "$(id -u)" != 0; then
-        echo "This task currently requires full root"; exit 1
-    fi
-    # testcloud barfs on .raw
-    if test -n "${bcvk}"; then
-      bcvk to-disk --format=qcow2 --disk-size "${SIZE}" --filesystem ext4 {{container}} {{target}}
-    else
-      TMPDISK={{target}}.raw
-      truncate -s "${SIZE}" "${TMPDISK}"
-      podman run \
-        --rm \
-        --privileged \
-        --pid=host \
-        --security-opt label=type:unconfined_t \
-        -v /var/lib/containers:/var/lib/containers \
-        -v /dev:/dev \
-        -v $(pwd)/target:/target \
-        localhost/bootc-integration \
-        bootc install to-disk \
-        --filesystem "ext4" \
-        --karg=console=ttyS0,115200n8 \
-        --generic-image \
-        --via-loopback \
-        /target/$(basename ${TMPDISK})
-      qemu-img convert -f raw -O qcow2 ${TMPDISK} {{target}}
-      rm -f "${TMPDISK}"
-    fi
-
+    bcvk to-disk --format=qcow2 --disk-size 20G --filesystem ext4 {{container}} {{target}}
 
 # These tests accept the container image as input, and may spawn it.
 run-container-external-tests:

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -33,4 +33,6 @@ just build-integration-test-image
 # Host builds will have this already, but we use it as a general dumping space
 # for output artifacts
 mkdir -p target
+# Debugging for https://github.com/bootc-dev/bcvk/issues/65
+echo ulimit=$(ulimit -Hn)
 just build-disk-image localhost/bootc-integration target/bootc-integration-test.qcow2


### PR DESCRIPTION
Make builds unprivileged by default and start using bcvk in our own CI, the same way we expect people to do so locally now.