### PR TITLE
bootloader: Mount the ESP with restricted fmask+dmask

### DIFF
--- a/crates/lib/src/bootc_composefs/finalize.rs
+++ b/crates/lib/src/bootc_composefs/finalize.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use crate::bootc_composefs::boot::{get_esp_partition, get_sysroot_parent_dev, BootType};
+use crate::bootc_composefs::boot::{
+    get_esp_partition, get_sysroot_parent_dev, mount_esp, BootType,
+};
 use crate::bootc_composefs::rollback::{rename_exchange_bls_entries, rename_exchange_user_cfg};
 use crate::spec::Bootloader;
 use crate::{
@@ -85,7 +87,7 @@ pub(crate) async fn composefs_backend_finalize() -> Result<()> {
     // NOTE: Assumption here that ESP will always be present
     let (esp_part, ..) = get_esp_partition(&sysroot_parent)?;
 
-    let esp_mount = TempMount::mount_dev(&esp_part)?;
+    let esp_mount = mount_esp(&esp_part)?;
     let boot_dir = Dir::open_ambient_dir("/sysroot/boot", ambient_authority())
         .context("Opening sysroot/boot")?;
 

--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -2,11 +2,10 @@ use std::{io::Read, sync::OnceLock};
 
 use anyhow::{Context, Result};
 use bootc_kernel_cmdline::utf8::Cmdline;
-use bootc_mount::tempmount::TempMount;
 use fn_error_context::context;
 
 use crate::{
-    bootc_composefs::boot::{get_esp_partition, get_sysroot_parent_dev, BootType},
+    bootc_composefs::boot::{get_esp_partition, get_sysroot_parent_dev, mount_esp, BootType},
     composefs_consts::{COMPOSEFS_CMDLINE, TYPE1_ENT_PATH, USER_CFG},
     parsers::{
         bls_config::{parse_bls_config, BLSConfig, BLSConfigType},
@@ -349,7 +348,7 @@ pub(crate) async fn composefs_deployment_status() -> Result<Host> {
             let parent = get_sysroot_parent_dev()?;
             let (esp_part, ..) = get_esp_partition(&parent)?;
 
-            let esp_mount = TempMount::mount_dev(&esp_part)?;
+            let esp_mount = mount_esp(&esp_part)?;
 
             let dir = esp_mount.fd.try_clone().context("Cloning fd")?;
             let guard = Some(esp_mount);

--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -9,8 +9,7 @@ use bootc_blockdev::{Partition, PartitionTable};
 use bootc_mount as mount;
 
 #[cfg(any(feature = "composefs-backend", feature = "install-to-disk"))]
-use bootc_mount::tempmount::TempMount;
-
+use crate::bootc_composefs::boot::mount_esp;
 use crate::utils;
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)
@@ -90,7 +89,7 @@ pub(crate) fn install_systemd_boot(
         .find(|p| p.parttype.as_str() == ESP_GUID)
         .ok_or_else(|| anyhow::anyhow!("ESP partition not found"))?;
 
-    let esp_mount = TempMount::mount_dev(&esp_part.node).context("Mounting ESP")?;
+    let esp_mount = mount_esp(&esp_part.node).context("Mounting ESP")?;
     let esp_path = Utf8Path::from_path(esp_mount.dir.path())
         .ok_or_else(|| anyhow::anyhow!("Failed to convert ESP mount path to UTF-8"))?;
 


### PR DESCRIPTION
This avoids warnings from `bootctl install` for good reasons. Visible from `bootc install` using systemd-boot.