### PR TITLE
Use pesign instead of sbsign

### DIFF
--- a/Dockerfile.cfsuki
+++ b/Dockerfile.cfsuki
@@ -1,13 +1,18 @@
 # Override via --build-arg=base=<image> to use a different base
 ARG base=localhost/bootc
 # This is where we get the tools to build the UKI
-ARG buildroot=quay.io/fedora/fedora:42
+ARG buildroot=quay.io/centos/centos:stream10
 FROM $base AS base
 
 FROM $buildroot as buildroot-base
 RUN <<EORUN
 set -xeuo pipefail
-dnf install -y systemd-ukify sbsigntools systemd-boot-unsigned
+
+# systemd-udev is required for /usr/lib/systemd/systemd-measure which
+# is used by ukify as invoked with the `--measure` flag below.  Not
+# strictly required, but nice to have the measured PCR values in the
+# output.
+dnf install -y systemd-ukify systemd-udev pesign openssl systemd-boot-unsigned
 dnf clean all
 EORUN
 
@@ -28,6 +33,13 @@ RUN --mount=type=secret,id=key \
     # TODO: https://github.com/containers/composefs-rs/issues/183
     cmdline="composefs=${COMPOSEFS_FSVERITY} root=UUID=4f68bce3-e8cd-4db1-96e7-fbcaf984b709 console=ttyS0,114800n8 enforcing=0 rw"
 
+    # pesign uses NSS database so create it from input cert/key
+    mkdir pesign
+    certutil -N -d pesign --empty-password
+    openssl pkcs12 -export -password 'pass:' -inkey /run/secrets/key -in /run/secrets/cert -out db.p12
+    pk12util -i db.p12 -W '' -d pesign
+    subject=$(openssl x509 -in /run/secrets/cert -subject | grep '^subject=CN=' | sed 's/^subject=CN=//')
+
     kver=$(cd /target/usr/lib/modules && echo *)
     ukify build \
         --linux "/target/usr/lib/modules/$kver/vmlinuz" \
@@ -35,18 +47,20 @@ RUN --mount=type=secret,id=key \
         --uname="${kver}" \
         --cmdline "${cmdline}" \
         --os-release "@/target/usr/lib/os-release" \
-        --signtool sbsign \
-        --secureboot-private-key "/run/secrets/key" \
-        --secureboot-certificate "/run/secrets/cert" \
+        --signtool pesign \
+        --secureboot-certificate-dir "pesign" \
+        --secureboot-certificate-name "${subject}" \
         --measure \
         --json pretty \
         --output "/boot/$kver.efi"
     # Sign systemd-boot as well
     sdboot="/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
-    sbsign \
-        --key "/run/secrets/key" \
-        --cert "/run/secrets/cert" \
-        "${sdboot}"
+    pesign \
+        --certdir "pesign" \
+        --certificate "${subject}" \
+        --in "${sdboot}" \
+        --out "${sdboot}.signed" \
+        --sign
     mv "${sdboot}.signed" "${sdboot}"
 EOF
 


### PR DESCRIPTION
This more closely aligns with how kernel-uki-virt is signed today, and
eliminates the requirement to use Fedora for the UKI toolchain.
Subsequently, this also switches the UKI toolchain to use c10s.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
