### PR TITLE
Fix a few instances of oddball baud rate

### DIFF
--- a/Dockerfile.cfsuki
+++ b/Dockerfile.cfsuki
@@ -26,7 +26,7 @@ RUN --mount=type=secret,id=key \
     # Inject the composefs kernel argument and specify a root with the x86_64 DPS UUID.
     # TODO: Discoverable partition fleshed out, or drop root UUID as systemd-stub extension
     # TODO: https://github.com/containers/composefs-rs/issues/183
-    cmdline="composefs=${COMPOSEFS_FSVERITY} root=UUID=4f68bce3-e8cd-4db1-96e7-fbcaf984b709 console=ttyS0,114800n8 enforcing=0 rw"
+    cmdline="composefs=${COMPOSEFS_FSVERITY} root=UUID=4f68bce3-e8cd-4db1-96e7-fbcaf984b709 console=ttyS0,115200n8 enforcing=0 rw"
 
     kver=$(cd /target/usr/lib/modules && echo *)
     ukify build \

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -211,7 +211,7 @@ pub(crate) struct InstallConfigOpts {
 
     /// Add a kernel argument.  This option can be provided multiple times.
     ///
-    /// Example: --karg=nosmt --karg=console=ttyS0,114800n8
+    /// Example: --karg=nosmt --karg=console=ttyS0,115200n8
     #[clap(long)]
     pub(crate) karg: Option<Vec<String>>,
 

--- a/docs/src/building/kernel-arguments.md
+++ b/docs/src/building/kernel-arguments.md
@@ -29,7 +29,7 @@ architecture specific via the `match-architectures` key:
 
 ```
 # /usr/lib/bootc/kargs.d/00-console.toml
-kargs = ["console=ttyS0,114800n8"]
+kargs = ["console=ttyS0,115200n8"]
 match-architectures = ["x86_64"]
 ```
 


### PR DESCRIPTION
Claude pointed this out while I was working on something else
completely unrelated.  But it looks like somewhere along the way
114800 snuck its way in and probably got copy/pasted into a few
places.  The maximum baud rate is 115200[1], and that is the more
typical usage.

[1] https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
