### PR TITLE
lib: Remove composefs-backend feature gate

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -74,13 +74,11 @@ similar-asserts = { workspace = true }
 static_assertions = { workspace = true }
 
 [features]
-default = ["install-to-disk", "composefs-backend"]
+default = ["install-to-disk"]
 # This feature enables `bootc install to-disk`, which is considered just a "demo"
 # or reference installer; we expect most nontrivial use cases to be using
 # `bootc install to-filesystem`.
 install-to-disk = []
-# Enable support for the composefs native backend
-composefs-backend = []
 # This featuares enables `bootc internals publish-rhsm-facts` to integrate with
 # Red Hat Subscription Manager
 rhsm = []

--- a/crates/lib/src/bootc_composefs/delete.rs
+++ b/crates/lib/src/bootc_composefs/delete.rs
@@ -43,8 +43,8 @@ fn delete_type1_entry(depl: &DeploymentEntry, boot_dir: &Dir, deleting_staged: b
     // We reuse kernel + initrd if they're the same for two deployments
     // We don't want to delete the (being deleted) deployment's kernel + initrd
     // if it's in use by any other deployment
-    let should_del_kernel = match &depl.deployment.boot_digest {
-        Some(digest) => find_vmlinuz_initrd_duplicates(&digest)?
+    let should_del_kernel = match depl.deployment.boot_digest.as_ref() {
+        Some(digest) => find_vmlinuz_initrd_duplicates(digest)?
             .is_some_and(|vec| vec.iter().any(|digest| *digest != depl.deployment.verity)),
         None => false,
     };

--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -8,7 +8,6 @@ use fn_error_context::context;
 use bootc_blockdev::{Partition, PartitionTable};
 use bootc_mount as mount;
 
-#[cfg(any(feature = "composefs-backend", feature = "install-to-disk"))]
 use crate::bootc_composefs::boot::mount_esp;
 use crate::{discoverable_partition_specification, utils};
 
@@ -72,7 +71,6 @@ pub(crate) fn install_via_bootupd(
 }
 
 #[context("Installing bootloader")]
-#[cfg(any(feature = "composefs-backend", feature = "install-to-disk"))]
 pub(crate) fn install_systemd_boot(
     device: &PartitionTable,
     _rootfs: &Utf8Path,

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -4,7 +4,6 @@
 //! to provide a fully "container native" tool for using
 //! bootable container images.
 
-#[cfg(feature = "composefs-backend")]
 mod bootc_composefs;
 pub(crate) mod bootc_kargs;
 mod bootloader;

--- a/crates/lib/src/lints.rs
+++ b/crates/lib/src/lints.rs
@@ -27,7 +27,6 @@ use linkme::distributed_slice;
 use ostree_ext::ostree_prepareroot;
 use serde::Serialize;
 
-#[cfg(feature = "composefs-backend")]
 use crate::bootc_composefs::boot::EFI_LINUX;
 
 /// Reference to embedded default baseimage content that should exist.
@@ -770,7 +769,6 @@ fn check_boot(root: &Dir, config: &LintExecutionConfig) -> LintResult {
         })
         .collect();
     let mut entries = entries?;
-    #[cfg(feature = "composefs-backend")]
     {
         // Work around https://github.com/containers/composefs-rs/issues/131
         let efidir = Utf8Path::new(EFI_LINUX)

--- a/crates/lib/src/spec.rs
+++ b/crates/lib/src/spec.rs
@@ -11,7 +11,6 @@ use ostree_ext::{container::OstreeImageReference, oci_spec};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "composefs-backend")]
 use crate::bootc_composefs::boot::BootType;
 use crate::{k8sapitypes, status::Slot};
 
@@ -201,7 +200,6 @@ impl FromStr for Bootloader {
 /// A bootable entry
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-#[cfg(feature = "composefs-backend")]
 pub struct BootEntryComposefs {
     /// The erofs verity
     pub verity: String,
@@ -235,7 +233,6 @@ pub struct BootEntry {
     /// If this boot entry is ostree based, the corresponding state
     pub ostree: Option<BootEntryOstree>,
     /// If this boot entry is composefs based, the corresponding state
-    #[cfg(feature = "composefs-backend")]
     pub composefs: Option<BootEntryComposefs>,
 }
 
@@ -272,7 +269,6 @@ pub struct HostStatus {
     pub ty: Option<HostType>,
 }
 
-#[cfg(feature = "composefs-backend")]
 pub(crate) struct DeploymentEntry<'a> {
     pub(crate) ty: Option<Slot>,
     pub(crate) deployment: &'a BootEntryComposefs,
@@ -315,7 +311,6 @@ impl Host {
         }
     }
 
-    #[cfg(feature = "composefs-backend")]
     pub(crate) fn require_composefs_booted(&self) -> anyhow::Result<&BootEntryComposefs> {
         let cfs = self
             .status
@@ -328,7 +323,6 @@ impl Host {
     }
 
     /// Returns all composefs deployments in a list
-    #[cfg(feature = "composefs-backend")]
     #[fn_error_context::context("Getting all composefs deployments")]
     pub(crate) fn all_composefs_deployments<'a>(&'a self) -> Result<Vec<DeploymentEntry<'a>>> {
         let mut all_deps = vec![];
@@ -636,7 +630,6 @@ mod tests {
                 pinned: false,
                 store: None,
                 ostree: None,
-                #[cfg(feature = "composefs-backend")]
                 composefs: None,
             }
         }

--- a/crates/lib/src/status.rs
+++ b/crates/lib/src/status.rs
@@ -19,10 +19,8 @@ use ostree_ext::sysroot::SysrootLock;
 
 use ostree_ext::ostree;
 
-#[cfg(feature = "composefs-backend")]
 use crate::bootc_composefs::status::{composefs_booted, composefs_deployment_status};
 use crate::cli::OutputFormat;
-#[cfg(feature = "composefs-backend")]
 use crate::spec::BootEntryComposefs;
 use crate::spec::ImageStatus;
 use crate::spec::{BootEntry, BootOrder, Host, HostSpec, HostStatus, HostType};
@@ -212,7 +210,6 @@ fn boot_entry_from_deployment(
             deploy_serial: deployment.deployserial().try_into().unwrap(),
             stateroot: deployment.stateroot().into(),
         }),
-        #[cfg(feature = "composefs-backend")]
         composefs: None,
     };
     Ok(r)
@@ -234,7 +231,6 @@ impl BootEntry {
         }
     }
 
-    #[cfg(feature = "composefs-backend")]
     pub(crate) fn require_composefs(&self) -> Result<&BootEntryComposefs> {
         self.composefs.as_ref().ok_or(anyhow::anyhow!(
             "BootEntry is not a composefs native boot entry"
@@ -349,7 +345,6 @@ pub(crate) fn get_status(
     Ok((deployments, host))
 }
 
-#[cfg(feature = "composefs-backend")]
 async fn get_host() -> Result<Host> {
     let host = if ostree_booted()? {
         let sysroot = super::cli::get_storage().await?;
@@ -359,21 +354,6 @@ async fn get_host() -> Result<Host> {
         host
     } else if composefs_booted()?.is_some() {
         composefs_deployment_status().await?
-    } else {
-        Default::default()
-    };
-
-    Ok(host)
-}
-
-#[cfg(not(feature = "composefs-backend"))]
-async fn get_host() -> Result<Host> {
-    let host = if ostree_booted()? {
-        let sysroot = super::cli::get_storage().await?;
-        let ostree = sysroot.get_ostree()?;
-        let booted_deployment = ostree.booted_deployment();
-        let (_deployments, host) = get_status(&ostree, booted_deployment.as_ref())?;
-        host
     } else {
         Default::default()
     };
@@ -524,7 +504,6 @@ fn human_render_slot(
     writeln!(out, "{digest} ({arch})")?;
 
     // Write the EROFS verity if present
-    #[cfg(feature = "composefs-backend")]
     if let Some(composefs) = &entry.composefs {
         write_row_name(&mut out, "Verity", prefix_len)?;
         writeln!(out, "{}", composefs.verity)?;
@@ -631,7 +610,6 @@ fn human_render_slot_ostree(
 }
 
 /// Output a rendering of a non-container composefs boot entry.
-#[cfg(feature = "composefs-backend")]
 fn human_render_slot_composefs(
     mut out: impl Write,
     slot: Slot,
@@ -666,7 +644,6 @@ fn human_readable_output_booted(mut out: impl Write, host: &Host, verbose: bool)
                 writeln!(out)?;
             }
 
-            #[cfg(feature = "composefs-backend")]
             if let Some(image) = &host_status.image {
                 human_render_slot(&mut out, Some(slot_name), host_status, image, verbose)?;
             } else if let Some(ostree) = host_status.ostree.as_ref() {
@@ -679,21 +656,6 @@ fn human_readable_output_booted(mut out: impl Write, host: &Host, verbose: bool)
                 )?;
             } else if let Some(composefs) = &host_status.composefs {
                 human_render_slot_composefs(&mut out, slot_name, host_status, &composefs.verity)?;
-            } else {
-                writeln!(out, "Current {slot_name} state is unknown")?;
-            }
-
-            #[cfg(not(feature = "composefs-backend"))]
-            if let Some(image) = &host_status.image {
-                human_render_slot(&mut out, Some(slot_name), host_status, image, verbose)?;
-            } else if let Some(ostree) = host_status.ostree.as_ref() {
-                human_render_slot_ostree(
-                    &mut out,
-                    Some(slot_name),
-                    host_status,
-                    &ostree.checksum,
-                    verbose,
-                )?;
             } else {
                 writeln!(out, "Current {slot_name} state is unknown")?;
             }

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -37,7 +37,6 @@ use crate::utils::deployment_fd;
 /// See https://github.com/containers/composefs-rs/issues/159
 pub type ComposefsRepository =
     composefs::repository::Repository<composefs::fsverity::Sha512HashValue>;
-#[cfg(feature = "composefs-backend")]
 pub type ComposefsFilesystem = composefs::tree::FileSystem<composefs::fsverity::Sha512HashValue>;
 
 /// Path to the physical root

--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::io::Write;
 use std::os::fd::BorrowedFd;
-#[cfg(feature = "composefs-backend")]
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -202,7 +201,6 @@ pub(crate) fn digested_pullspec(image: &str, digest: &str) -> String {
     format!("{image}@{digest}")
 }
 
-#[cfg(feature = "composefs-backend")]
 #[derive(Debug)]
 pub enum EfiError {
     SystemNotUEFI,
@@ -213,14 +211,12 @@ pub enum EfiError {
     Io(std::io::Error),
 }
 
-#[cfg(feature = "composefs-backend")]
 impl From<std::io::Error> for EfiError {
     fn from(e: std::io::Error) -> Self {
         EfiError::Io(e)
     }
 }
 
-#[cfg(feature = "composefs-backend")]
 pub fn read_uefi_var(var_name: &str) -> Result<String, EfiError> {
     use crate::install::EFIVARFS;
     use cap_std_ext::cap_std::ambient_authority;
@@ -262,7 +258,6 @@ pub fn read_uefi_var(var_name: &str) -> Result<String, EfiError> {
 /// Computes a relative path from `from` to `to`.
 ///
 /// Both `from` and `to` must be absolute paths.
-#[cfg(feature = "composefs-backend")]
 pub(crate) fn path_relative_to(from: &Path, to: &Path) -> Result<PathBuf> {
     if !from.is_absolute() || !to.is_absolute() {
         anyhow::bail!("Paths must be absolute");
@@ -321,7 +316,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "composefs-backend")]
     fn test_relative_path() {
         let from = Path::new("/sysroot/state/deploy/image_id");
         let to = Path::new("/sysroot/state/os/default/var");

--- a/docs/src/experimental-composefs.md
+++ b/docs/src/experimental-composefs.md
@@ -9,7 +9,7 @@ Tracking issue: <https://github.com/bootc-dev/bootc/issues/1190>
 
 The composefs backend is an experimental alternative storage backend that uses [composefs-rs](https://github.com/containers/composefs-rs) instead of ostree for storing and managing bootc system deployments.
 
-**Status**: Experimental. The composefs backend is under active development and not yet suitable for production use. The feature is currently gated behind the `composefs-backend` compile-time feature flag, which in current git main is enabled by default.
+**Status**: Experimental. The composefs backend is under active development and not yet suitable for production use. The feature is always compiled in as of bootc v1.10.1.
 
 ## Key Benefits
 


### PR DESCRIPTION
While composefs is still experimental, after looking at this I think the feature gating we're doing has a pretty high "pain:gain" ratio - in other words, the risk we're mitigating by having it off is very low.

Since composefs is a focus of development, let's just remove the feature gate. We have good CI coverage for the non-composefs case.

Assisted-by: Claude Code (Sonnet 4.5)