### PR TITLE
kargs: correctly split kernel command-line string with quoted arguments

### DIFF
--- a/crates/lib/src/bootc_kargs.rs
+++ b/crates/lib/src/bootc_kargs.rs
@@ -124,7 +124,10 @@ pub(crate) fn get_kargs(
     // Get the kargs used for the merge in the bootloader config
     if let Some(bootconfig) = ostree::Deployment::bootconfig(merge_deployment) {
         if let Some(options) = ostree::BootconfigParser::get(&bootconfig, "options") {
-            let options = options.split_whitespace().map(|s| s.to_owned());
+            let options = bootc_kernel_cmdline::utf8::Cmdline::from(options.as_str())
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>();
             kargs.extend(options);
         }
     };


### PR DESCRIPTION
Splitting the kernel command-line on whitespace breaks quoted arguments, e.g., "dyndbg=\"file drivers/base/firmware_loader/main.c +fmp\"".

Use the bootc_kernel_cmdline crate to parse and split kernel arguments, which unbreaks deployment when a quoted kernel argument is present.

Closes: https://github.com/ostreedev/ostree/issues/3544