### PR TITLE
tests: Use systemd-i128 over uuidgen

### DIFF
--- a/tests/build-sealed
+++ b/tests/build-sealed
@@ -28,7 +28,7 @@ if test -z "${secureboot}"; then
   cd $secureboot
   if test '!' -f db.cer; then
     echo "Generating test Secure Boot keys"
-    uuidgen --random > GUID.txt
+    systemd-id128 new -u > GUID.txt
     openssl req -quiet -newkey rsa:4096 -nodes -keyout PK.key -new -x509 -sha256 -days 3650 -subj '/CN=Test Platform Key/' -out PK.crt
     openssl x509 -outform DER -in PK.crt -out PK.cer
     openssl req -quiet -newkey rsa:4096 -nodes -keyout KEK.key -new -x509 -sha256 -days 3650 -subj '/CN=Test Key Exchange Key/' -out KEK.crt

--- a/tmt/tests/examples/bootc-uki/build.final
+++ b/tmt/tests/examples/bootc-uki/build.final
@@ -19,7 +19,7 @@ if [[ ! -d "secureboot" ]]; then
     echo "Generating test Secure Boot keys"
     mkdir secureboot
     pushd secureboot > /dev/null
-    uuidgen --random > GUID.txt
+    systemd-id128 new -u > GUID.txt
     openssl req -newkey rsa:4096 -nodes -keyout PK.key -new -x509 -sha256 -days 3650 -subj "/CN=Test Platform Key/" -out PK.crt
     openssl x509 -outform DER -in PK.crt -out PK.cer
     openssl req -newkey rsa:4096 -nodes -keyout KEK.key -new -x509 -sha256 -days 3650 -subj "/CN=Test Key Exchange Key/" -out KEK.crt


### PR DESCRIPTION
`just test-composefs` fails in the new default devcontainer ref <https://github.com/bootc-dev/infra/blob/main/common/.devcontainer> without this.