### PR TITLE
build-sys: Run most parts with `--network=none`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,11 +86,11 @@ FROM build as units
 # A place that we're more likely to be able to set xattrs
 VOLUME /var/tmp
 ENV TMPDIR=/var/tmp
-RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/roothome --network=none make install-unit-tests
+RUN --mount=type=cache,target=/src/target --mount=type=cache,target=/var/roothome --network=none make install-unit-tests
 
 # This just does syntax checking
 FROM build as validate
-RUN --mount=type=cache,target=/build/target --mount=type=cache,target=/var/roothome --network=none make validate
+RUN --mount=type=cache,target=/src/target --mount=type=cache,target=/var/roothome --network=none make validate
 
 # The final image that derives from the original base and adds the release binaries
 FROM base


### PR DESCRIPTION
Why? It just shows that we have put some thought into our build system and care about reproducibility, hermetic builds etc. And yes of course, `--network=bridge` should probably have been required as an opt-in in Dockerfile, but oh well. It's not too bad to sprinkle `--network=none` in some places. The biggest one is wrapping `make`.