### PR TITLE
ci: Add a required-checks context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,16 @@ jobs:
         with:
           name: tmt-log-PR-${{ github.event.number }}-${{ matrix.test_os }}-cfs-${{ env.ARCH }}
           path: /var/tmp/tmt
+
+  # Sentinel job for required checks - configure this job name in repository settings
+  required-checks:
+    if: always()
+    needs: [cargo-deny, validate, test-integration, test-integration-cfs]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: >-
+          needs.cargo-deny.result != 'success' ||
+          needs.validate.result != 'success' ||
+          needs.test-integration.result != 'success' ||
+          needs.test-integration-cfs.result != 'success'


### PR DESCRIPTION
This copies the approach taken in bcvk, so when we change our CI jobs I don't need to go and manually edit the GH configuration.

(A followup step here is to have automation to cut over all repositories
 to do things this way)