### PR TITLE
Fix deprecation warning for rustix::thread::Capability

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -740,7 +740,7 @@ pub(crate) fn require_root(is_container: bool) -> Result<()> {
     );
 
     ensure!(
-        rustix::thread::capability_is_in_bounding_set(rustix::thread::Capability::SystemAdmin)?,
+        rustix::thread::capability_is_in_bounding_set(rustix::thread::CapabilitySet::SYS_ADMIN)?,
         if is_container {
             "The container must be executed with full privileges (e.g. --privileged flag)"
         } else {


### PR DESCRIPTION
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
