### PR TITLE
store: Preserve /sysroot readonly for read-only operations

### DIFF
--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -36,6 +36,7 @@ use crate::composefs_consts::{
 use crate::spec::Bootloader;
 
 /// A parsed composefs command line
+#[derive(Clone)]
 pub(crate) struct ComposefsCmdline {
     #[allow(dead_code)]
     pub insecure: bool,

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -721,8 +721,11 @@ pub(crate) fn ensure_self_unshared_mount_namespace() -> Result<()> {
 /// This prepares the process for write operations (re-exec, mount namespace, etc).
 #[context("Initializing storage")]
 pub(crate) async fn get_storage() -> Result<crate::store::BootedStorage> {
+    let env = crate::store::Environment::detect()?;
+    // Always call prepare_for_write() for write operations - it checks
+    // for container, root privileges, mount namespace setup, etc.
     prepare_for_write()?;
-    let r = BootedStorage::new()
+    let r = BootedStorage::new(env)
         .await?
         .ok_or_else(|| anyhow!("System not booted via bootc"))?;
     Ok(r)

--- a/crates/lib/src/status.rs
+++ b/crates/lib/src/status.rs
@@ -369,7 +369,12 @@ pub(crate) fn get_status(
 }
 
 async fn get_host() -> Result<Host> {
-    let Some(storage) = BootedStorage::new().await? else {
+    let env = crate::store::Environment::detect()?;
+    if env.needs_mount_namespace() {
+        crate::cli::prepare_for_write()?;
+    }
+
+    let Some(storage) = BootedStorage::new(env).await? else {
         // If we're not booted, then return a default.
         return Ok(Host::default());
     };

--- a/tmt/tests/booted/readonly/001-test-status.nu
+++ b/tmt/tests/booted/readonly/001-test-status.nu
@@ -4,6 +4,22 @@ use tap.nu
 tap begin "verify bootc status output formats"
 
 let st = bootc status --json | from json
+# Detect composefs by checking if composefs field is present
+let is_composefs = ($st.status.booted.composefs? != null)
+
+# FIXME: Should be mounting /sysroot readonly in composefs by default
+if not $is_composefs {
+    # Verify /sysroot is not writable initially (read-only operations should not make it writable)
+    let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
+    assert (not $is_writable) "/sysroot should not be writable initially"
+
+    # Double-check with findmnt
+    let mnt = (findmnt /sysroot -J | from json)
+    let opts = ($mnt.filesystems.0.options | split row ",")
+    assert ($opts | any { |o| $o == "ro" }) "/sysroot should be mounted read-only"
+}
+
+let st = bootc status --json | from json
 assert equal $st.apiVersion org.containers.bootc/v1
 
 let st = bootc status --json --format-version=0 | from json
@@ -11,8 +27,6 @@ assert equal $st.apiVersion org.containers.bootc/v1
 
 let st = bootc status --format=yaml | from yaml
 assert equal $st.apiVersion org.containers.bootc/v1
-# Detect composefs by checking if composefs field is present
-let is_composefs = ($st.status.booted.composefs? != null)
 if not $is_composefs {
     assert ($st.status.booted.image.timestamp != null)
 } # else { TODO composefs: timestamp is not populated with composefs }
@@ -23,12 +37,17 @@ if $ostree != null {
 
 let st = bootc status --json --booted | from json
 assert equal $st.apiVersion org.containers.bootc/v1
-# Detect composefs by checking if composefs field is present
-let is_composefs = ($st.status.booted.composefs? != null)
 if not $is_composefs {
     assert ($st.status.booted.image.timestamp != null)
 } # else { TODO composefs: timestamp is not populated with composefs }
 assert (($st.status | get rollback | default null) == null)
 assert (($st.status | get staged | default null) == null)
+
+# FIXME: See above re /sysroot ro
+if not $is_composefs {
+    # Verify /sysroot is still not writable after bootc status (regression test for PR #1718)
+    let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
+    assert (not $is_writable) "/sysroot should remain read-only after bootc status"
+}
 
 tap ok


### PR DESCRIPTION
PR #1718 introduced a regression where /sysroot was left writable after running `bootc status`. This occurred because BootedStorage::new() unconditionally calls set_mount_namespace_in_use(), which tells ostree it can safely remount /sysroot as writable. When sysroot.load() is called without actually being in a mount namespace, it leaves the global /sysroot writable.

Fix by introducing an Environment enum that detects the runtime environment (ostree, composefs, container, or other) early in the execution flow. Callers now detect the environment and call prepare_for_write() if needed before constructing BootedStorage. This ensures a single call to prepare_for_write() per execution path and eliminates the previous layering violation where storage code called into CLI code.

The Environment abstraction also makes it clearer when mount namespace setup is required and provides a foundation for future environment-specific behavior.

Assisted-by: Claude Code (Sonnet 4.5)