### PR TITLE
build-sys: Reinstall fedora-bootc-destructive-cleanup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,6 @@ FROM base
 ARG variant
 RUN <<EORUN
 set -xeuo pipefail
-# Ensure we've flushed out prior state (i.e. files no longer shipped from the old version);
-# and yes, we may need to go to building an RPM in this Dockerfile by default.
-rm -vf /usr/lib/systemd/system/multi-user.target.wants/bootc-*
 case "${variant}" in
   *-sdboot)
     dnf -y install systemd-boot-unsigned
@@ -123,6 +120,10 @@ type = "${fs}"
 EOF
   fi
 fi
+
+# Ensure we've flushed out prior state (i.e. files no longer shipped from the old version);
+# and yes, we may need to go to building an RPM in this Dockerfile by default.
+(set +x; rpm -ql bootc | while read line; do if test -f $line; then rm -v $line; fi; done)
 EORUN
 # Create a layer that is our new binaries
 COPY --from=build /out/ /

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ install:
 	# Copy dracut and systemd config files
 	cp -Prf baseimage/dracut $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/dracut
 	cp -Prf baseimage/systemd $(DESTDIR)$(prefix)/share/doc/bootc/baseimage/systemd
+	# Install fedora-bootc-destructive-cleanup in fedora derivatives
+	ID=$$(. /usr/lib/os-release && echo $$ID); \
+	ID_LIKE=$$(. /usr/lib/os-release && echo $$ID_LIKE); \
+	if [ "$$ID" = "fedora" ] || [[ "$$ID_LIKE" == *"fedora"* ]]; then \
+	install -D -m 0755 -t $(DESTDIR)/$(prefix)/lib/bootc contrib/scripts/fedora-bootc-destructive-cleanup; \
+	fi
 
 # Run this to also take over the functionality of `ostree container` for example.
 # Only needed for OS/distros that have callers invoking `ostree container` and not bootc.


### PR DESCRIPTION
When commit cd8fa591 moved unit enablement to a systemd generator, it also removed the installation of the fedora-bootc-destructive-cleanup script from the Makefile. This was unintentional - while the symlink enablement should be handled by the generator, the script itself still needs to be installed.

The trap is that because we weren't accurately removing old files from the build, the old version was still there...until the new upstream release.

Fix this in two ways:

First, continue to install the script on Fedora-like systems as before, but leave unit enablement to the generator as intended.

Second, change how we remove prior state to clean out all files from the RPM. (I did look at changing out the build system so we build an RPM in this case which would be cleaner, but it's a large change)

Fixes: https://github.com/bootc-dev/bootc/issues/1748
Assisted-by: Claude Code (Sonnet 4.5)