### PR TITLE
cli: Hide config-diff and delete-deployment

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -680,7 +680,9 @@ pub(crate) enum Opt {
     Internals(InternalsOpts),
     ComposefsFinalizeStaged,
     /// Diff current /etc configuration versus default
+    #[clap(hide = true)]
     ConfigDiff,
+    #[clap(hide = true)]
     DeleteDeployment {
         depl_id: String,
     },


### PR DESCRIPTION
These were added without docs or tests and
only apply right now to the composefs backend. Hide them until they meet the above quality bars.