### PR TITLE
test: Fix factory reset test failure on CS10

### DIFF
--- a/tmt/tests/booted/test-factory-reset.nu
+++ b/tmt/tests/booted/test-factory-reset.nu
@@ -41,6 +41,15 @@ def initial_build [] {
     # nu's cp doesn't have -T
     /usr/bin/cp -r -T $workdir_root $"($new_stateroot_path)/($workdir_root)"
 
+    # Check reset status before reboot
+    RUST_LOG=trace bootc status
+
+    # Sometimes systemd daemons are still running old binaries and response "Access denied" when send reboot request
+    # Force a full sync before reboot
+    sync
+    # Allow more delay for bootc to settle
+    sleep 30sec
+
     tmt-reboot
 }
 


### PR DESCRIPTION
Sometimes systemd daemons are still running old binaries and response "Access denied" when send reboot request.

This PR forces a full sync before reboot and allow more delay for bootc to settle.