### PR TITLE
xtask: Fix deprecation warnings with rand 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,7 +3305,7 @@ dependencies = [
  "fn-error-context",
  "mandown",
  "owo-colors",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "tar",

--- a/crates/xtask/src/xtask.rs
+++ b/crates/xtask/src/xtask.rs
@@ -491,11 +491,11 @@ fn verify_ssh_connectivity(sh: &Shell, port: u16, key_path: &Utf8Path) -> Result
 
 /// Generate a random alphanumeric suffix for VM names
 fn generate_random_suffix() -> String {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
     (0..8)
         .map(|_| {
-            let idx = rng.gen_range(0..CHARSET.len());
+            let idx = rng.random_range(0..CHARSET.len());
             CHARSET[idx] as char
         })
         .collect()


### PR DESCRIPTION
The rand crate was bumped from 0.8 -> 0.9 in 7804be96

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
