### PR TITLE
initramfs: Mount /sysroot readonly for composefs by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "composefs",
  "composefs-boot",
  "fn-error-context",
+ "libc",
  "rustix",
  "serde",
  "toml",

--- a/crates/initramfs/Cargo.toml
+++ b/crates/initramfs/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["std", "help", "usage", "derive"] }
+libc.workspace = true
 rustix.workspace = true
 serde = { workspace = true, features = ["derive"] }
 composefs.workspace = true

--- a/tmt/tests/booted/readonly/001-test-status.nu
+++ b/tmt/tests/booted/readonly/001-test-status.nu
@@ -3,23 +3,19 @@ use tap.nu
 
 tap begin "verify bootc status output formats"
 
+# Verify /sysroot is not writable initially (read-only operations should not make it writable)
+let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
+assert (not $is_writable) "/sysroot should not be writable initially"
+
+# Double-check with findmnt
+let mnt = (findmnt /sysroot -J | from json)
+let opts = ($mnt.filesystems.0.options | split row ",")
+assert ($opts | any { |o| $o == "ro" }) "/sysroot should be mounted read-only"
+
 let st = bootc status --json | from json
 # Detect composefs by checking if composefs field is present
 let is_composefs = ($st.status.booted.composefs? != null)
 
-# FIXME: Should be mounting /sysroot readonly in composefs by default
-if not $is_composefs {
-    # Verify /sysroot is not writable initially (read-only operations should not make it writable)
-    let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
-    assert (not $is_writable) "/sysroot should not be writable initially"
-
-    # Double-check with findmnt
-    let mnt = (findmnt /sysroot -J | from json)
-    let opts = ($mnt.filesystems.0.options | split row ",")
-    assert ($opts | any { |o| $o == "ro" }) "/sysroot should be mounted read-only"
-}
-
-let st = bootc status --json | from json
 assert equal $st.apiVersion org.containers.bootc/v1
 
 let st = bootc status --json --format-version=0 | from json
@@ -43,11 +39,8 @@ if not $is_composefs {
 assert (($st.status | get rollback | default null) == null)
 assert (($st.status | get staged | default null) == null)
 
-# FIXME: See above re /sysroot ro
-if not $is_composefs {
-    # Verify /sysroot is still not writable after bootc status (regression test for PR #1718)
-    let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
-    assert (not $is_writable) "/sysroot should remain read-only after bootc status"
-}
+# Verify /sysroot is still not writable after bootc status (regression test for PR #1718)
+let is_writable = (do -i { /bin/test -w /sysroot } | complete | get exit_code) == 0
+assert (not $is_writable) "/sysroot should remain read-only after bootc status"
 
 tap ok


### PR DESCRIPTION
This implements readonly mounting of /sysroot for composefs systems, matching the behavior that ostree systems already have. Previously, composefs left /sysroot mounted read-write, which was inconsistent and meant the readonly tests had to be skipped for composefs.

The implementation uses a direct `libc::syscall` wrapper for `mount_setattr` since rustix doesn't yet provide this API. The `MOUNT_ATTR_RDONLY` flag is applied recursively to three mount points during initramfs setup:
- The composefs rootfs image mount (becomes `/` after switch-root)
- The test root filesystem mount (used in testing scenarios)
- The sysroot clone mount (becomes `/sysroot` in the booted system)

With this change, the readonly /sysroot tests in test-status.nu now run for both ostree and composefs systems without conditional checks.

Assisted-by: Claude Code (Sonnet 4.5)