### PR TITLE
Install UKI Addons globally

### DIFF
--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -504,7 +504,7 @@ pub(crate) fn setup_composefs_bls_boot(
                 .with_title(title)
                 .with_sort_key(default_sort_key.into())
                 .with_version(version)
-                .with_cfg(BLSConfigType::NonEFI {
+                .with_cfg(BLSConfigType::NonUKI {
                     linux: entry_paths.abs_entries_path.join(&id_hex).join(VMLINUZ),
                     initrd: vec![entry_paths.abs_entries_path.join(&id_hex).join(INITRD)],
                     options: Some(cmdline_refs),
@@ -515,7 +515,7 @@ pub(crate) fn setup_composefs_bls_boot(
                     let symlink_to = &symlink_to[0];
 
                     match bls_config.cfg_type {
-                        BLSConfigType::NonEFI {
+                        BLSConfigType::NonUKI {
                             ref mut linux,
                             ref mut initrd,
                             ..
@@ -810,8 +810,8 @@ fn write_systemd_uki_config(
     let mut bls_conf = BLSConfig::default();
     bls_conf
         .with_title(boot_label.boot_label)
-        .with_cfg(BLSConfigType::EFI {
-            efi: format!("/{SYSTEMD_UKI_DIR}/{}{}", id.to_hex(), EFI_EXT).into(),
+        .with_cfg(BLSConfigType::UKI {
+            uki: format!("/{SYSTEMD_UKI_DIR}/{}{}", id.to_hex(), EFI_EXT).into(),
         })
         .with_sort_key(default_sort_key.into())
         .with_version(boot_label.version.unwrap_or(default_sort_key.into()));

--- a/crates/lib/src/bootc_composefs/delete.rs
+++ b/crates/lib/src/bootc_composefs/delete.rs
@@ -9,7 +9,7 @@ use crate::{
     bootc_composefs::{
         boot::{
             find_vmlinuz_initrd_duplicates, get_efi_uuid_source, get_esp_partition,
-            get_sysroot_parent_dev, mount_esp, BootType, SYSTEMD_UKI_DIR,
+            get_sysroot_parent_dev, mount_esp, BootType, BOOTC_UKI_DIR,
         },
         gc::composefs_gc,
         repo::open_composefs_repo,
@@ -156,7 +156,7 @@ fn delete_kernel_initrd(bls_config: &BLSConfigType, boot_dir: &Dir) -> Result<()
 #[fn_error_context::context("Deleting UKI and UKI addons {uki_id}")]
 fn delete_uki(uki_id: &str, esp_mnt: &Dir) -> Result<()> {
     // TODO: We don't delete global addons here
-    let ukis = esp_mnt.open_dir(SYSTEMD_UKI_DIR)?;
+    let ukis = esp_mnt.open_dir(BOOTC_UKI_DIR)?;
 
     for entry in ukis.entries_utf8()? {
         let entry = entry?;

--- a/crates/lib/src/bootc_composefs/delete.rs
+++ b/crates/lib/src/bootc_composefs/delete.rs
@@ -65,20 +65,20 @@ fn delete_type1_entry(depl: &DeploymentEntry, boot_dir: &Dir, deleting_staged: b
         let bls_config = parse_bls_config(&cfg)?;
 
         match &bls_config.cfg_type {
-            BLSConfigType::EFI { efi } => {
-                if !efi.as_str().contains(&depl.deployment.verity) {
+            BLSConfigType::UKI { uki } => {
+                if !uki.as_str().contains(&depl.deployment.verity) {
                     continue;
                 }
 
                 // Boot dir in case of EFI will be the ESP
-                tracing::debug!("Deleting EFI .conf file: {}", file_name);
+                tracing::debug!("Deleting UKI .conf file: {}", file_name);
                 entry.remove_file().context("Removing .conf file")?;
                 delete_uki(&depl.deployment.verity, boot_dir)?;
 
                 break;
             }
 
-            BLSConfigType::NonEFI { options, .. } => {
+            BLSConfigType::NonUKI { options, .. } => {
                 let options = options
                     .as_ref()
                     .ok_or(anyhow::anyhow!("options not found in BLS config file"))?;
@@ -87,7 +87,7 @@ fn delete_type1_entry(depl: &DeploymentEntry, boot_dir: &Dir, deleting_staged: b
                     continue;
                 }
 
-                tracing::debug!("Deleting non-EFI .conf file: {}", file_name);
+                tracing::debug!("Deleting non-UKI .conf file: {}", file_name);
                 entry.remove_file().context("Removing .conf file")?;
 
                 if should_del_kernel {
@@ -116,8 +116,8 @@ fn delete_type1_entry(depl: &DeploymentEntry, boot_dir: &Dir, deleting_staged: b
 
 #[fn_error_context::context("Deleting kernel and initrd")]
 fn delete_kernel_initrd(bls_config: &BLSConfigType, boot_dir: &Dir) -> Result<()> {
-    let BLSConfigType::NonEFI { linux, initrd, .. } = bls_config else {
-        anyhow::bail!("Found EFI config")
+    let BLSConfigType::NonUKI { linux, initrd, .. } = bls_config else {
+        anyhow::bail!("Found UKI config")
     };
 
     // "linux" and "initrd" are relative to the boot_dir in our config files

--- a/crates/lib/src/bootc_composefs/state.rs
+++ b/crates/lib/src/bootc_composefs/state.rs
@@ -44,17 +44,17 @@ pub(crate) fn get_booted_bls(boot_dir: &Dir) -> Result<BLSConfig> {
 
     for entry in sorted_entries {
         match &entry.cfg_type {
-            BLSConfigType::EFI { efi } => {
+            BLSConfigType::UKI { uki } => {
                 let composefs_param_value = booted.value().ok_or_else(|| {
                     anyhow::anyhow!("Failed to get composefs kernel cmdline value")
                 })?;
 
-                if efi.as_str().contains(composefs_param_value) {
+                if uki.as_str().contains(composefs_param_value) {
                     return Ok(entry);
                 }
             }
 
-            BLSConfigType::NonEFI { options, .. } => {
+            BLSConfigType::NonUKI { options, .. } => {
                 let Some(opts) = options else {
                     anyhow::bail!("options not found in bls config")
                 };

--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -377,13 +377,13 @@ pub(crate) async fn composefs_deployment_status_from(
                     .ok_or(anyhow::anyhow!("First boot entry not found"))?;
 
                 match &bls_config.cfg_type {
-                    BLSConfigType::NonEFI { options, .. } => !options
+                    BLSConfigType::NonUKI { options, .. } => !options
                         .as_ref()
                         .ok_or(anyhow::anyhow!("options key not found in bls config"))?
                         .contains(composefs_digest.as_ref()),
 
-                    BLSConfigType::EFI { .. } => {
-                        anyhow::bail!("Found 'efi' field in Type1 boot entry")
+                    BLSConfigType::UKI { .. } => {
+                        anyhow::bail!("Found 'uki' field in Type1 boot entry")
                     }
                     BLSConfigType::Unknown => anyhow::bail!("Unknown BLS Config Type"),
                 }
@@ -410,10 +410,10 @@ pub(crate) async fn composefs_deployment_status_from(
 
             match &bls_config.cfg_type {
                 // For UKI boot
-                BLSConfigType::EFI { efi } => efi.as_str().contains(composefs_digest.as_ref()),
+                BLSConfigType::UKI { uki } => uki.as_str().contains(composefs_digest.as_ref()),
 
                 // For boot entry Type1
-                BLSConfigType::NonEFI { options, .. } => !options
+                BLSConfigType::NonUKI { options, .. } => !options
                     .as_ref()
                     .ok_or(anyhow::anyhow!("options key not found in bls config"))?
                     .contains(composefs_digest.as_ref()),
@@ -486,7 +486,7 @@ mod tests {
         let mut config1 = BLSConfig::default();
         config1.title = Some("Fedora 42.20250623.3.1 (CoreOS)".into());
         config1.sort_key = Some("1".into());
-        config1.cfg_type = BLSConfigType::NonEFI {
+        config1.cfg_type = BLSConfigType::NonUKI {
             linux: "/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/vmlinuz-5.14.10".into(),
             initrd: vec!["/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/initramfs-5.14.10.img".into()],
             options: Some("root=UUID=abc123 rw composefs=7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6".into()),
@@ -495,7 +495,7 @@ mod tests {
         let mut config2 = BLSConfig::default();
         config2.title = Some("Fedora 41.20250214.2.0 (CoreOS)".into());
         config2.sort_key = Some("2".into());
-        config2.cfg_type = BLSConfigType::NonEFI {
+        config2.cfg_type = BLSConfigType::NonUKI {
             linux: "/boot/febdf62805de2ae7b6b597f2a9775d9c8a753ba1e5f09298fc8fbe0b0d13bf01/vmlinuz-5.14.10".into(),
             initrd: vec!["/boot/febdf62805de2ae7b6b597f2a9775d9c8a753ba1e5f09298fc8fbe0b0d13bf01/initramfs-5.14.10.img".into()],
             options: Some("root=UUID=abc123 rw composefs=febdf62805de2ae7b6b597f2a9775d9c8a753ba1e5f09298fc8fbe0b0d13bf01".into())

--- a/crates/lib/src/parsers/grub_menuconfig.rs
+++ b/crates/lib/src/parsers/grub_menuconfig.rs
@@ -15,6 +15,8 @@ use nom::{
     Err, IResult, Parser,
 };
 
+use crate::bootc_composefs::boot::BOOTC_UKI_DIR;
+
 /// Body content of a GRUB menuentry containing parsed commands.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct MenuentryBody<'a> {
@@ -95,7 +97,7 @@ impl<'a> MenuEntry<'a> {
             title: format!("{boot_label}: ({uki_id})"),
             body: MenuentryBody {
                 insmod: vec!["fat", "chain"],
-                chainloader: format!("/EFI/Linux/{uki_id}.efi"),
+                chainloader: format!("/{BOOTC_UKI_DIR}/{uki_id}.efi"),
                 search: "--no-floppy --set=root --fs-uuid \"${EFI_PART_UUID}\"",
                 version: 0,
                 extra: vec![],


### PR DESCRIPTION
Until now we were scoping passed in UKI Addons to specific deployments,
but usecases like ignition, luks (for now at least), require the addons
to be applied to all deployments

Rename 'efi' key to 'uki' in BLSConfig

Key 'uki' is more appropriate for us as the PE Binary that the key
points to is a UKI