### PR TITLE
build-sys: Inject hvc0 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN --mount=type=bind,from=packaging,target=/run/packaging /run/packaging/config
 # Support overriding the rootfs at build time conveniently
 ARG rootfs=
 RUN --mount=type=bind,from=packaging,target=/run/packaging /run/packaging/configure-rootfs "${variant}" "${rootfs}"
+# Inject additional content
+COPY --from=packaging /usr-extras/ /usr/
 # Install the RPM built in the build stage
 # This replaces the manual file deletion hack and COPY, ensuring proper package management
 # Use rpm -Uvh with --oldpackage to allow replacing with dev version

--- a/contrib/packaging/README-usr-extras.md
+++ b/contrib/packaging/README-usr-extras.md
@@ -1,0 +1,8 @@
+# Understanding usr-extras
+
+The usr-extras directory contains
+content we inject into all container images
+built from this project.
+
+It is likely though that some of this will
+end up in downstream operating systems instead.

--- a/contrib/packaging/usr-extras/lib/bootc/kargs.d/21-console-hvc0.toml
+++ b/contrib/packaging/usr-extras/lib/bootc/kargs.d/21-console-hvc0.toml
@@ -1,0 +1,2 @@
+# https://bugzilla.redhat.com/show_bug.cgi?id=2353887
+kargs = ["console=hvc0"]


### PR DESCRIPTION
In order to debug failures more reliably we really always want a virtual console.

It turns out the Fedora kernel configs for a while have done https://gitlab.com/cki-project/kernel-ark/-/commit/9a0d7ce2af11ef7b9a3bc3073e13dc9983b7e245 which means hvc0 is available from very early boot.

I am probably going to argue to do this in all Fedora derivatives by default soon but let's start here.