### PR TITLE
Justfile: Bring back build-sealed target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,6 +36,10 @@ build:
     podman build {{base_buildargs}} -t localhost/bootc-bin {{buildargs}} .
     ./tests/build-sealed {{variant}} localhost/bootc-bin localhost/bootc
 
+# Build a sealed image from current sources.
+build-sealed:
+    @just --justfile {{justfile()}} variant=composefs-sealeduki-sdboot build
+
 # Build packages (e.g. RPM) using a container buildroot
 _packagecontainer:
     #!/bin/bash


### PR DESCRIPTION
Except now this wraps the "variant" usage of `just build`.  For one,
this is a convenient little piece of shorthand.  But perhaps more
importantly, we have this referenced in the docs.  Although I could go
change the docs to reflect the new usage, I think it just reads nicer
in the docs for it to remain `just build-sealed`.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
