### PR TITLE
cli: Fix rhsm feature propagation and manpage build order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,19 @@ prefix ?= /usr
 # We may in the future also want to include Fedora+derivatives as
 # the code is really tiny.
 # (Note we should also make installation of the units conditional on the rhsm feature)
-CARGO_FEATURES ?= $(shell . /usr/lib/os-release; if echo "$$ID_LIKE" |grep -qF rhel; then echo rhsm; fi)
+CARGO_FEATURES_DEFAULT ?= $(shell . /usr/lib/os-release; if echo "$$ID_LIKE" |grep -qF rhel; then echo rhsm; fi)
+# You can set this to override all cargo features, including the defaults
+CARGO_FEATURES ?= $(CARGO_FEATURES_DEFAULT)
 
-all: bin manpages
+# Build all binaries
+.PHONY: bin
+bin: manpages
+	cargo build --release --features "$(CARGO_FEATURES)" --bins
 
-bin:
-	cargo build --release --features "$(CARGO_FEATURES)"
-
+# Note this cargo build is run without features (such as rhsm)
 .PHONY: manpages
 manpages:
-	cargo run --package xtask -- manpages
+	cargo run --release --package xtask -- manpages
 
 STORAGE_RELATIVE_PATH ?= $(shell realpath -m -s --relative-to="$(prefix)/lib/bootc/storage" /sysroot/ostree/bootc/storage)
 install:

--- a/tmt/tests/booted/readonly/021-test-rhsm-facts.nu
+++ b/tmt/tests/booted/readonly/021-test-rhsm-facts.nu
@@ -1,0 +1,13 @@
+use std assert
+use tap.nu
+
+tap begin "rhsm facts"
+
+# Verify we have this feature
+if ("/etc/rhsm" | path exists) {
+    bootc internals publish-rhsm-facts --help
+    let status = systemctl show -P ActiveState bootc-publish-rhsm-facts.service
+    assert equal $status "inactive"
+}
+
+tap ok


### PR DESCRIPTION
The rhsm feature was not being propagated from the CLI crate to the lib crate, causing `bootc internals publish-rhsm-facts` to never be compiled in even when building with CARGO_FEATURES=rhsm.

I think this was broken when I refactored the build recently.

Change things so we build the manpages before the production binary, ensuring the production binary always ends up with the right feature flags.

Fixes: https://issues.redhat.com/browse/RHEL-130799
Assisted-by: Claude Code (Sonnet 4.5)