### PR TITLE
test: Add more distros for composefs test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Setup env
         run: |
-          BASE=$(just pullspec-for-os ${{ matrix.test_os }})
+          BASE=$(just pullspec-for-os base ${{ matrix.test_os }})
           echo "BOOTC_base=${BASE}" >> $GITHUB_ENV
 
       - name: Build container
@@ -175,13 +175,19 @@ jobs:
 
   # This variant does composefs testing
   test-integration-cfs:
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        # TODO expand this matrix, we need to make it better to override the target
         # OS via Justfile variables too
-        test_os: [centos-10]
+        test_os: [fedora-42, fedora-43, fedora-44, centos-10]
         variant: [composefs-sealeduki-sdboot]
+        experimental: [false]
+        # For issue https://github.com/bootc-dev/bootc/issues/1812
+        include:
+          - test_os: centos-9
+            variant: composefs-sealeduki-sdboot
+            experimental: true
 
     runs-on: ubuntu-24.04
 
@@ -196,13 +202,18 @@ jobs:
 
       - name: Setup env
         run: |
-          BASE=$(just pullspec-for-os ${{ matrix.test_os }})
+          BASE=$(just pullspec-for-os base ${{ matrix.test_os }})
+          BUILDROOTBASE=$(just pullspec-for-os buildroot-base ${{ matrix.test_os }})
           echo "BOOTC_base=${BASE}" >> $GITHUB_ENV
+          echo "BOOTC_buildroot_base=${BUILDROOTBASE}" >> $GITHUB_ENV
           echo "BOOTC_variant="${{ matrix.variant }} >> $GITHUB_ENV
 
       - name: Build container
         run: |
           just build-integration-test-image
+          # Extra cross-check (duplicating the integration test) that we're using the right base
+          used_vid=$(podman run --rm localhost/bootc-integration bash -c '. /usr/lib/os-release && echo ${ID}-${VERSION_ID}')
+          test ${{ matrix.test_os }} = "${used_vid}"
 
       - name: Unit and container integration tests
         run: just test-container

--- a/hack/os-image-map.json
+++ b/hack/os-image-map.json
@@ -1,9 +1,16 @@
 {
-  "rhel-9.8": "images.paas.redhat.com/bootc/rhel-bootc:latest-9.8",
-  "rhel-10.2": "images.paas.redhat.com/bootc/rhel-bootc:latest-10.2",
-  "centos-9": "quay.io/centos-bootc/centos-bootc:stream9",
-  "centos-10": "quay.io/centos-bootc/centos-bootc:stream10",
-  "fedora-42": "quay.io/fedora/fedora-bootc:42",
-  "fedora-43": "quay.io/fedora/fedora-bootc:43",
-  "fedora-44": "quay.io/fedora/fedora-bootc:rawhide"
+  "base": {
+    "centos-9": "quay.io/centos-bootc/centos-bootc:stream9",
+    "centos-10": "quay.io/centos-bootc/centos-bootc:stream10",
+    "fedora-42": "quay.io/fedora/fedora-bootc:42",
+    "fedora-43": "quay.io/fedora/fedora-bootc:43",
+    "fedora-44": "quay.io/fedora/fedora-bootc:rawhide"
+  },
+  "buildroot-base": {
+    "centos-9": "quay.io/centos/centos:stream9",
+    "centos-10": "quay.io/centos/centos:stream10",
+    "fedora-42": "quay.io/fedora/fedora:42",
+    "fedora-43": "quay.io/fedora/fedora:43",
+    "fedora-44": "quay.io/fedora/fedora:rawhide"
+  }
 }

--- a/hack/provision-packit.sh
+++ b/hack/provision-packit.sh
@@ -32,7 +32,7 @@ fi
 
 # Get base image URL
 TEST_OS="${ID}-${VERSION_ID}"
-BASE=$(jq -r --arg v "$TEST_OS" '.[$v]' < os-image-map.json)
+BASE=$(jq -r --arg v "$TEST_OS" '.base[$v]' < os-image-map.json)
 
 if [[ "$ID" == "rhel" ]]; then
     # OSCI gating only

--- a/tests/build-sealed
+++ b/tests/build-sealed
@@ -58,6 +58,9 @@ if test -z "${secureboot}"; then
   cd -
 fi
 
-runv podman build -t $output_image --build-arg=COMPOSEFS_FSVERITY=${cfs_digest} --build-arg=base=${input_image} \
+runv podman build -t $output_image \
+  --build-arg=COMPOSEFS_FSVERITY=${cfs_digest} \
+  --build-arg=base=${input_image} \
+  --build-arg=buildroot=${BOOTC_buildroot_base} \
   --secret=id=key,src=${secureboot}/db.key \
   --secret=id=cert,src=${secureboot}/db.crt -f Dockerfile.cfsuki .


### PR DESCRIPTION
This PR adds CS9, Fedora 42/43/44 distros for composefs test.