### PR TITLE
install/bootupd: chroot to deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
           # Install tests
           sudo bootc-integration-tests install-alongside localhost/bootc-install
 
+          # inspect system state after the install tests.
+          sudo lsblk
+          sudo mount
+          
           # system-reinstall-bootc tests
           cargo build --release -p system-reinstall-bootc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ version = "0.1.0"
 dependencies = [
  "anstream",
  "anyhow",
+ "cap-std-ext",
  "chrono",
  "owo-colors",
  "rustix",

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/bootc-dev/bootc"
 # Workspace dependencies
 anstream = { workspace = true }
 anyhow = { workspace = true }
+cap-std-ext = {workspace = true, features = ["fs_utf8"] }
 chrono = { workspace = true, features = ["std"] }
 owo-colors = { workspace = true }
 rustix = { workspace = true }

--- a/crates/utils/src/bwrap.rs
+++ b/crates/utils/src/bwrap.rs
@@ -1,0 +1,106 @@
+/// Builder for running commands inside a target os tree using bubblewrap (bwrap).
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::os::fd::AsRawFd;
+use std::process::Command;
+
+use anyhow::Result;
+use cap_std_ext::camino::{Utf8Path, Utf8PathBuf};
+use cap_std_ext::cap_std::fs::Dir;
+
+use crate::CommandRunExt;
+
+/// Builder for running commands inside a target directory using bwrap.
+#[derive(Debug)]
+pub struct BwrapCmd<'a> {
+    /// The target directory to use as root for the container
+    chroot_path: Cow<'a, Utf8Path>,
+    /// Bind mounts in format (source, target)
+    bind_mounts: Vec<(&'a str, &'a str)>,
+    /// Device nodes to bind into the container
+    devices: Vec<&'a str>,
+    /// Environment variables to set
+    env_vars: Vec<(&'a str, &'a str)>,
+}
+
+impl<'a> BwrapCmd<'a> {
+    /// Create a new BwrapCmd builder with a root directory as a File Descriptor.
+    #[allow(dead_code)]
+    pub fn new_with_dir(path: &'a Dir) -> Self {
+        let fd_path: String = format!("/proc/self/fd/{}", path.as_raw_fd());
+        Self {
+            chroot_path: Cow::Owned(Utf8PathBuf::from(&fd_path)),
+            bind_mounts: Vec::new(),
+            devices: Vec::new(),
+            env_vars: Vec::new(),
+        }
+    }
+
+    /// Create a new BwrapCmd builder with a root directory
+    pub fn new(path: &'a Utf8Path) -> Self {
+        Self {
+            chroot_path: Cow::Borrowed(path),
+            bind_mounts: Vec::new(),
+            devices: Vec::new(),
+            env_vars: Vec::new(),
+        }
+    }
+
+    /// Add a bind mount from source to target inside the container.
+    pub fn bind(
+        mut self,
+        source: &'a impl AsRef<Utf8Path>,
+        target: &'a impl AsRef<Utf8Path>,
+    ) -> Self {
+        self.bind_mounts
+            .push((source.as_ref().as_str(), target.as_ref().as_str()));
+        self
+    }
+
+    /// Bind a device node into the container.
+    pub fn bind_device(mut self, device: &'a str) -> Self {
+        self.devices.push(device);
+        self
+    }
+
+    /// Set an environment variable for the command.
+    pub fn setenv(mut self, key: &'a str, value: &'a str) -> Self {
+        self.env_vars.push((key, value));
+        self
+    }
+
+    /// Run the specified command inside the container.
+    pub fn run<S: AsRef<OsStr>>(self, args: impl IntoIterator<Item = S>) -> Result<()> {
+        let mut cmd = Command::new("bwrap");
+
+        // Bind the root filesystem
+        cmd.args(["--bind", self.chroot_path.as_str(), "/"]);
+
+        // Setup API filesystems
+        // See https://systemd.io/API_FILE_SYSTEMS/
+        cmd.args(["--proc", "/proc"]);
+        cmd.args(["--dev", "/dev"]);
+        cmd.args(["--ro-bind", "/sys", "/sys"]);
+
+        // Add bind mounts
+        for (source, target) in &self.bind_mounts {
+            cmd.args(["--bind", source, target]);
+        }
+
+        // Add device bind mounts
+        for device in self.devices {
+            cmd.args(["--dev-bind", device, device]);
+        }
+
+        // Add environment variables
+        for (key, value) in &self.env_vars {
+            cmd.args(["--setenv", key, value]);
+        }
+
+        // Command to run
+        cmd.arg("--");
+        cmd.args(args);
+
+        cmd.log_debug().run_inherited_with_cmd_context()
+    }
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -2,20 +2,22 @@
 //! things here that only depend on the standard library and
 //! "core" crates.
 //!
+mod bwrap;
+pub use bwrap::*;
 mod command;
 pub use command::*;
-mod path;
-pub use path::*;
 mod iterators;
 pub use iterators::*;
-mod timestamp;
-pub use timestamp::*;
-mod tracing_util;
-pub use tracing_util::*;
+mod path;
+pub use path::*;
 /// Re-execute the current process
 pub mod reexec;
 mod result_ext;
 pub use result_ext::*;
+mod timestamp;
+pub use timestamp::*;
+mod tracing_util;
+pub use tracing_util::*;
 
 /// The name of our binary
 pub const NAME: &str = "bootc";


### PR DESCRIPTION
When `--src-imgref` is passed, the deployed systemd does not match the running environnement. In this case, let's chroot into the deployment before calling bootupd. This makes sure we are using the binaries shipped in the image (and relevant config files such as grub fragements).

We could do that in all cases but i kept it behind the `--src-imgref` option since when using the target container as the buildroot it will have no impact, and we expect this scenario to be the most common.

In CoreOS we have a specific test that checks if the bootloader was installed with the `grub2-install` of the image.

Fixes https://github.com/bootc-dev/bootc/issues/1559 Also see https://github.com/bootc-dev/bootc/issues/1455