### PR TITLE
test: Fix flaky reboot issue in C10S

### DIFF
--- a/tmt/tests/booted/bootc_testlib.nu
+++ b/tmt/tests/booted/bootc_testlib.nu
@@ -4,11 +4,8 @@
 # that seems to have appeared in C10S
 # TODO diagnose and fill in here
 export def reboot [] {
-    # Sometimes systemd daemons are still running old binaries and response "Access denied" when send reboot request
-    # Force a full sync before reboot
-    sync
     # Allow more delay for bootc to settle
-    sleep 30sec
+    sleep 120sec
 
     tmt-reboot
 }


### PR DESCRIPTION
This PR is to fix `tmt-reboot` failed in `useroverlay` test in C10S. I tried 3 times, all passed. `sleep` is not the best solution, but it works in this case. I checked avc log, journal log and login permission. All looks good.

I also tried 60 seconds, filed one times in 2 runs. So 120 seconds is more stable from my try runs.