### PR TITLE
sdboot: add support for autoenroll in `bootc install`

### DIFF
--- a/docs/src/man/bootc-install.8.md
+++ b/docs/src/man/bootc-install.8.md
@@ -28,6 +28,10 @@ updates.
 An installation is not simply a copy of the container filesystem, but
 includes other setup and metadata.
 
+## Secure Boot Keys
+
+When installing with `systemd-boot`, bootc can let `systemd-boot` can handle enrollment of Secure Boot keys by putting signed EFI signature lists in `/usr/lib/bootc/install/secureboot-keys` which will copy over into `ESP/loader/keys` after bootloader installation. The keys will be copied to `loader/keys` subdirectory of the ESP. after installing `systemd-boot` to the system. More information on how key enrollment works with `systemd-boot` is available in the [systemd-boot](https://github.com/systemd/systemd/blob/26b2085d54ebbfca8637362eafcb4a8e3faf832f/man/systemd-boot.xml#L392) man page.
+
 <!-- BEGIN GENERATED OPTIONS -->
 <!-- END GENERATED OPTIONS -->
 


### PR DESCRIPTION
add autoenroll to sdboot

installs `.auth` files from `/usr/lib/bootc/keys` into `ESP/loader/keys/auto`. Currently uses cfs file APIs and is a little rough. Not sure if this should be in `composefs-boot` rather than `bootc`. The directory `/usr/lib/bootc/keys` probably isn't the best choice although at least it means that the auth files are "measured" when the cfs digest is taken.

Note that this is missing some of the bits from CI for this to be properly tested. I will try to get that done when I can though