### PR TITLE
cli: add `install print-configuration --root-dir`

### DIFF
--- a/docs/src/man/bootc-install-print-configuration.8.md
+++ b/docs/src/man/bootc-install-print-configuration.8.md
@@ -26,6 +26,12 @@ string-valued filesystem name suitable for passing to `mkfs.\$type`.
 
     Print all configuration
 
+**--sysroot**=*SYSROOT*
+
+    Set an alternative root filesystem
+
+    Default: /
+
 <!-- END GENERATED OPTIONS -->
 
 # VERSION


### PR DESCRIPTION
[draft as this is potentially controversial, also build on top f #1820 mostly to avoid conflicts]

We would like to only inspect a container image with
{bootc,}image-builder and not actually run the container.

One reason is (too much?) paranoia, i.e. we want to eventually
support bootc containers coming from the users that get passed
into the service and not having to run anything on the container
initially to generate the osbuild manifest minimizes the risk.

So to still get the require parameters like preferred rootfs
or kargs we would like to run our own bootc and then pass
```
bootc install print-configuration --root-dir /path/to/mounted/cnt
```
to generate the manifest. The actual build will still run
the `boots install to-filesystem` from the container. But that
step happens in an isolated instance that is destroyed after
each build (we already do this for package based image builds
as users can also inject custom content/rpms here).

This PR implements this new "--root-dir" option.

It also tweaks print_configuration to make it easier to
test. With that we could drop parts of the tests for
PR#1820 from the container.rs and move them in here.

(c.f. https://github.com/osbuild/images/pull/1988)