### PR TITLE
composefs/usr: Fix /usr permissions on overlay mount

### DIFF
--- a/crates/lib/src/bootc_composefs/state.rs
+++ b/crates/lib/src/bootc_composefs/state.rs
@@ -246,7 +246,7 @@ pub(crate) fn composefs_usr_overlay() -> Result<()> {
         return Ok(());
     }
 
-    overlay_transient(usr)?;
+    overlay_transient(usr, Some(0o755.into()))?;
 
     println!("A writeable overlayfs is now mounted on /usr");
     println!("All changes there will be discarded on reboot.");


### PR DESCRIPTION
The upper,work directories being created for `/usr` transient mount always had the mode `0o700` hence only being accessible to root

Update `bootc_initramfs_setup::ensure_dir` to accept an optional `mode` argument

Fixes: https://github.com/bootc-dev/bootc/issues/1833