### PR TITLE
lib/composefs: Add error check for unsupported --download-only flag

### DIFF
--- a/crates/lib/src/bootc_composefs/update.rs
+++ b/crates/lib/src/bootc_composefs/update.rs
@@ -266,6 +266,11 @@ pub(crate) async fn upgrade_composefs(
     storage: &Storage,
     composefs: &BootedComposefs,
 ) -> Result<()> {
+    // Download-only mode is not yet supported for composefs backend
+    if opts.download_only {
+        anyhow::bail!("--download-only is not yet supported for composefs backend");
+    }
+
     let host = get_composefs_status(storage, composefs)
         .await
         .context("Getting composefs deployment status")?;


### PR DESCRIPTION
The previous commit (c325582f) added --download-only support for the OSTree backend but did not add an error check for the composefs backend where this feature is not yet implemented.

This commit adds a proper error message at the start of upgrade_composefs() to explicitly bail out when --download-only is used, matching the pattern used for other unsupported composefs features like --mutate-in-place and edit operations.

Without this check, the flag would be silently ignored, potentially causing confusion for users expecting download-only behavior.

Error message: "--download-only is not yet supported for composefs backend"