### PR TITLE
lib: Add --from-downloaded flag for bootc upgrade

### DIFF
--- a/crates/lib/src/bootc_composefs/update.rs
+++ b/crates/lib/src/bootc_composefs/update.rs
@@ -276,6 +276,9 @@ pub(crate) async fn upgrade_composefs(
     if opts.download_only {
         anyhow::bail!("--download-only is not yet supported for composefs backend");
     }
+    if opts.from_downloaded {
+        anyhow::bail!("--from-downloaded is not yet supported for composefs backend");
+    }
 
     let host = get_composefs_status(storage, composefs)
         .await

--- a/docs/src/man/bootc-upgrade.8.md
+++ b/docs/src/man/bootc-upgrade.8.md
@@ -65,6 +65,10 @@ Soft reboot allows faster system restart by avoiding full hardware reboot when p
 
     Download and stage the update without applying it
 
+**--from-downloaded**
+
+    Apply a staged deployment that was previously downloaded with --download-only
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/tmt/plans/integration.fmf
+++ b/tmt/plans/integration.fmf
@@ -95,12 +95,12 @@ execute:
     test:
       - /tmt/tests/tests/test-25-soft-reboot
 
-/plan-25-download-only-upgrade:
+/plan-26-download-only-upgrade:
   summary: Execute download-only upgrade tests
   discover:
     how: fmf
     test:
-      - /tmt/tests/tests/test-25-download-only-upgrade
+      - /tmt/tests/tests/test-26-download-only-upgrade
 
 /plan-27-custom-selinux-policy:
   summary: Execute custom selinux policy test

--- a/tmt/tests/booted/test-download-only-upgrade.nu
+++ b/tmt/tests/booted/test-download-only-upgrade.nu
@@ -1,4 +1,4 @@
-# number: 25
+# number: 26
 # tmt:
 #   summary: Execute download-only upgrade tests
 #   duration: 40m
@@ -13,7 +13,7 @@
 # reboot (should still boot into v1, staged deployment discarded)
 # verify staged deployment is null (discarded on reboot)
 # bootc upgrade --download-only (re-stage v2 in download-only mode)
-# bootc upgrade (clear download-only mode)
+# bootc upgrade --from-downloaded (clear download-only mode without fetching from image source)
 # reboot (should boot into v2)
 #
 use std assert
@@ -113,9 +113,9 @@ def third_boot [] {
     assert ($status_json.status.staged != null) "Staged deployment should exist"
     assert ($status_json.status.staged.downloadOnly) "Staged deployment should be in download-only mode"
 
-    # Now clear download-only mode by running upgrade without flags
-    print "Clearing download-only mode with bootc upgrade"
-    bootc upgrade
+    # Now clear download-only mode by running upgrade --from-downloaded (without fetching from image source)
+    print "Clearing download-only mode with bootc upgrade --from-downloaded"
+    bootc upgrade --from-downloaded
 
     # Verify via JSON that deployment is not in download-only mode
     let status_after_json = bootc status --json | from json

--- a/tmt/tests/tests.fmf
+++ b/tmt/tests/tests.fmf
@@ -41,10 +41,10 @@
   duration: 30m
   test: nu booted/test-soft-reboot.nu
 
-/test-25-download-only-upgrade:
+/test-26-download-only-upgrade:
   summary: Execute download-only upgrade tests
   duration: 40m
-  test: nu booted/test-25-download-only-upgrade.nu
+  test: nu booted/test-download-only-upgrade.nu
 
 /test-27-custom-selinux-policy:
   summary: Execute custom selinux policy test


### PR DESCRIPTION
Add a new --from-downloaded flag to bootc upgrade that allows users to unlock a staged deployment created with --download-only without checking for newer updates from the registry.

This provides a way to apply already-downloaded updates without triggering a registry check, which is useful for scheduled maintenance workflows where the update was downloaded earlier and should now be applied at a scheduled time.

Usage:
  # Download update without applying
  bootc upgrade --download-only

  # Later: Apply the staged update (no registry check)
  bootc upgrade --from-downloaded

  # Or: Apply staged update and reboot immediately
  bootc upgrade --from-downloaded --apply

The flag conflicts with --check and --download-only as those operations have different purposes. It can be combined with --apply to immediately reboot after unlocking the staged deployment.

This commit also updates the documentation (upgrades.md) to describe all three ways to apply a download-only update, and updates the download-only test case (test-25) to use --apply-staged instead of plain `bootc upgrade` when clearing the download-only flag.

Assisted-by: Claude Code (Sonnet 4.5)