### PR TITLE
lib: Pass absolute authfile path when pulling LBIs

### DIFF
--- a/tmt/tests/booted/readonly/010-test-bootc-container-store.nu
+++ b/tmt/tests/booted/readonly/010-test-bootc-container-store.nu
@@ -15,6 +15,14 @@ if $is_composefs {
 
     # And verify this works
     bootc image cmd list -q o>/dev/null
+
+    bootc image cmd pull busybox
+    podman --storage-opt=additionalimagestore=/usr/lib/bootc/storage image exists busybox
+
+    'corrupted JSON!@#%!@#' | save -f /run/ostree/auth.json
+    let e = bootc image cmd pull busybox | complete | get exit_code
+    assert not equal $e 0
+    rm -v /run/ostree/auth.json
 }
 
 tap ok

--- a/tmt/tests/booted/test-logically-bound-switch.nu
+++ b/tmt/tests/booted/test-logically-bound-switch.nu
@@ -21,6 +21,11 @@ bootc status
 let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
+# The tests here aren't fetching from a registry which requires auth by default,
+# but we can replicate the failure in https://github.com/bootc-dev/bootc/pull/1852
+# by just injecting any auth file.
+echo '{}' | save -f /run/ostree/auth.json
+
 def initial_setup [] {
     bootc image copy-to-storage
     podman images


### PR DESCRIPTION
ostree-ext explicitly handles authfile paths as relative; this works fine for most callers of get_global_authfile, as they only read the returned open file descriptor, and ignore the path. However, pulling logically bound images requires passing the actual authfile path to Podman, so we must resolve the absolute path in this case - otherwise, we see errors like the following:

```
[root@fedora ~]# bootc upgrade
layers already present: 69; layers needed: 1 (242.2 MB)
Fetched layers: 230.95 MiB in 3 seconds (90.88 MiB/s)
  Deploying: done (3 seconds)
  Fetching bound image: quay.io/prometheus/node-exporter:v1.10.2: done (0 seconds)
error: Upgrading: Staging: Pulling bound images: Pulling bound images: Failed to pull image: Subprocess failed: ExitStatus(unix_wait_status(32000))
Error: credential file is not accessible: faccessat etc/ostree/auth.json: no such file or directory
```

Since cap_std::fs::Dir intentionally does not expose its filesystem path, we must resort to reconstructing it from a file descriptor. We could do this by inspectingthe file descriptor for `sysroot` and combining that with the relative path returned by get_global_authfile, but since get_global_authfile returns the descriptor of the actual authfile, we can simply read that directly.