### PR TITLE
cli: Fix switch --mutate-in-place to work outside booted environment

### DIFF
--- a/tmt/plans/integration.fmf
+++ b/tmt/plans/integration.fmf
@@ -140,4 +140,11 @@ execute:
     how: fmf
     test:
       - /tmt/tests/tests/test-31-switch-to-unified
+
+/plan-31-switch-mutate-in-place:
+  summary: switch --mutate-in-place
+  discover:
+    how: fmf
+    test:
+      - /tmt/tests/tests/test-31-switch-mutate-in-place
 # END GENERATED PLANS

--- a/tmt/tests/booted/test-switch-mutate-in-place.nu
+++ b/tmt/tests/booted/test-switch-mutate-in-place.nu
@@ -1,0 +1,21 @@
+# number: 31
+# tmt:
+#   summary: switch --mutate-in-place
+#   duration: 30m
+#
+use std assert
+use tap.nu
+use bootc_testlib.nu
+
+# See https://github.com/bootc-dev/bootc/issues/1854
+
+let st = bootc status --json | from json
+let is_composefs = ($st.status.booted.composefs? != null)
+if not $is_composefs {
+    # This is aiming to reproduce an environment closer to the Anaconda case
+    # where we're chrooted into a non-booted system. TODO: What we really want
+    # is to add `bootc switch --sysroot` too.
+    mv /run/ostree-booted /run/ostree-booted.orig
+    unshare -m /bin/sh -c 'mount -o remount,rw /sysroot && bootc switch --mutate-in-place quay.io/nosuchimage/image-to-test-switch'
+    tap ok
+}

--- a/tmt/tests/tests.fmf
+++ b/tmt/tests/tests.fmf
@@ -74,3 +74,8 @@
   summary: Onboard to unified storage, build derived image, and switch to it
   duration: 30m
   test: nu booted/test-switch-to-unified.nu
+
+/test-31-switch-mutate-in-place:
+  summary: switch --mutate-in-place
+  duration: 30m
+  test: nu booted/test-switch-mutate-in-place.nu


### PR DESCRIPTION
Move the --mutate-in-place handling before get_storage() so it doesn't require a fully booted ostree environment. This enables use cases like Anaconda where we're chrooted into a non-booted system.

Closes: #1854
Assisted-by: OpenCode (claude-sonnet-4-20250514)