### PR TITLE
ostree-ext: Fix warning on rust 1.9.2

### DIFF
--- a/crates/ostree-ext/src/cli.rs
+++ b/crates/ostree-ext/src/cli.rs
@@ -1262,7 +1262,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     imgref,
                     image,
                     transport,
-                    mut no_signature_verification,
+                    no_signature_verification: _,
                     enforce_container_sigpolicy,
                     ostree_remote,
                     target_imgref,
@@ -1273,7 +1273,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 } => {
                     // As of recent releases, signature verification enforcement is
                     // off by default, and must be explicitly enabled.
-                    no_signature_verification = !enforce_container_sigpolicy;
+                    let no_signature_verification = !enforce_container_sigpolicy;
                     let sysroot = &if let Some(sysroot) = sysroot {
                         ostree::Sysroot::new(Some(&gio::File::for_path(sysroot)))
                     } else {


### PR DESCRIPTION
This started warning with:

warning: value assigned to `no_signature_verification` is never read
    --> crates/ostree-ext/src/cli.rs:1265:21
     |
1265 |                     mut no_signature_verification,
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: maybe it is overwritten before being read?
     = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default

Which is true in this case, we never actually read the pattern-matched
value.  Change it to be explicitly unused with '_' and then shadow it
with a `let` binding.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
