### PR TITLE
ci: add crates-release.yml workflow to publish to crates.io

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -1,0 +1,22 @@
+# See https://crates.io/docs/trusted-publishing
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*']  # Triggers when pushing tags starting with 'v'
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v6
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: |
+        for crate in bootc-internal-utils bootc-internal-blockdev; do
+          echo "Publishing $crate..."
+          cargo publish -p "$crate"
+          echo "Successfully published $crate"
+        done
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Publish two crates:
`bootc-internal-utils` and `bootc-internal-blockdev`

Part of https://github.com/bootc-dev/infra/issues/20