### PR TITLE
cli: use file extension for host spec to be edited

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1284,7 +1284,7 @@ async fn edit_ostree(
         let mut r = std::io::BufReader::new(std::fs::File::open(filename)?);
         serde_yaml::from_reader(&mut r)?
     } else {
-        let tmpf = tempfile::NamedTempFile::new()?;
+        let tmpf = tempfile::NamedTempFile::with_suffix(".yaml")?;
         serde_yaml::to_writer(std::io::BufWriter::new(tmpf.as_file()), &host)?;
         crate::utils::spawn_editor(&tmpf)?;
         tmpf.as_file().seek(std::io::SeekFrom::Start(0))?;


### PR DESCRIPTION
Plays well with editors' language detection (for syntax highlighting).

<img width="225" height="170" alt="Screenshot 2025-12-17 at 22 36 46" src="https://github.com/user-attachments/assets/2fc8919b-ad80-47c1-a8e7-797ef416e58c" />
<img width="190" height="170" alt="Screenshot 2025-12-17 at 22 35 03" src="https://github.com/user-attachments/assets/a91b6119-a67d-4fee-9792-154399e266a1" />
