### PR TITLE
renovate: Ignore bootc-dev/infra synced GitHub workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,12 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // These files are synced from the bootc-dev/infra repository, which sends
+  // PRs to update them. Ignoring them here to avoid conflicting Renovate updates.
+  "ignorePaths": [
+    ".github/workflows/rebase.yml",
+    ".github/workflows/openssf-scorecard.yml",
+    ".github/actions/bootc-ubuntu-setup/action.yml",
+    ".github/actions/setup-rust/action.yml"
+  ]
 }


### PR DESCRIPTION
To avoid duplicate github action and workflow update.

The renovate can update action and workflows in `bootc-dev/infra`. When the update PR in `bootc-dev/infra` merged, the push triggers the `syn common` to send PR to update action and workflows in this repo.