### PR TITLE
Silence cloud-init warnings around rootfs

### DIFF
--- a/hack/provision-derived.sh
+++ b/hack/provision-derived.sh
@@ -59,6 +59,13 @@ mkdir -p /etc/cloud/cloud.cfg.d
 cat > /etc/cloud/cloud.cfg.d/80-enable-root.cfg <<'CLOUDEOF'
 # Enable root login for testing
 disable_root: false
+
+# In image mode, the host root filesystem is mounted at /sysroot, not /
+# That is the one we should attempt to resize, not what is mounted at /
+growpart:
+  mode: auto
+  devices: ["/sysroot"]
+resize_rootfs: false
 CLOUDEOF
 fi
 


### PR DESCRIPTION
Silence cloud-init warnings about resizing rootfs. More discussion in https://gitlab.com/fedora/bootc/examples/-/merge_requests/78