### PR TITLE
ostree-ext: Fix unused import warning in objgv tests

### DIFF
--- a/crates/ostree-ext/src/objgv.rs
+++ b/crates/ostree-ext/src/objgv.rs
@@ -19,7 +19,6 @@ mod tests {
     use gvariant::aligned_bytes::TryAsAligned;
     use gvariant::Marker;
 
-    use super::*;
     #[test]
     fn test_dirtree() {
         // Just a compilation test


### PR DESCRIPTION
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
