### PR TITLE
test/tmt: Use `bootc usroverlay` for /usr overlay mount

### DIFF
--- a/tmt/tests/booted/test-install-outside-container.nu
+++ b/tmt/tests/booted/test-install-outside-container.nu
@@ -30,9 +30,8 @@ umount /var/mnt
 setenforce 0
 systemd-run -p MountFlags=slave -qdPG -- /bin/sh -c $"
 set -xeuo pipefail
+bootc usr-overlay
 if test -d /sysroot/ostree; then mount --bind /usr/share/empty /sysroot/ostree; fi
-mkdir -p /tmp/ovl/{upper,work}
-mount -t overlay -olowerdir=/usr,workdir=/tmp/ovl/work,upperdir=/tmp/ovl/upper overlay /usr
 # Note we do keep the other bootupd state
 rm -vrf /usr/lib/bootupd/updates
 # Another bootc install bug, we should not look at this in outside-of-container flows

--- a/tmt/tests/booted/test-install-unified-flag.nu
+++ b/tmt/tests/booted/test-install-unified-flag.nu
@@ -29,9 +29,8 @@ def main [] {
     # We use systemd-run to handle mount namespace issues
     systemd-run -p MountFlags=slave -qdPG -- /bin/sh -c $"
 set -xeuo pipefail
+bootc usr-overlay
 if test -d /sysroot/ostree; then mount --bind /usr/share/empty /sysroot/ostree; fi
-mkdir -p /tmp/ovl/{upper,work}
-mount -t overlay -olowerdir=/usr,workdir=/tmp/ovl/work,upperdir=/tmp/ovl/upper overlay /usr
 # Note we do keep the other bootupd state
 rm -vrf /usr/lib/bootupd/updates
 # Another bootc install bug, we should not look at this in outside-of-container flows


### PR DESCRIPTION
Previously we were mounting a rw overlay on top of /usr using `mount -t overlay -olowerdir=/usr,workdir=...,upperdir=... overlay /usr` which caused the kernel to throw
`overlayfs: maximum fs stacking depth exceeded`
possibly because the mountpoint was the same as the lowerdir

Also, move the overlay mount BEFORE we mask off `/sysroot/ostree` else bootc throws `error: Read only filesystem`