### PR TITLE
Update workspace to Rust edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "toml",
  "tracing",
  "uapi-version",
+ "unicode-width",
  "uuid",
  "xshell",
 ]

--- a/crates/blockdev/Cargo.toml
+++ b/crates/blockdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Internal implementation component of bootc; do not use"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "bootc-internal-blockdev"
 repository = "https://github.com/bootc-dev/bootc"

--- a/crates/blockdev/src/blockdev.rs
+++ b/crates/blockdev/src/blockdev.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use regex::Regex;

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc"
 # This is a stub, the real version is from the lib crate
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bootc-dev/bootc"
 publish = false

--- a/crates/initramfs/Cargo.toml
+++ b/crates/initramfs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc-initramfs-setup"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/crates/initramfs/src/lib.rs
+++ b/crates/initramfs/src/lib.rs
@@ -11,11 +11,11 @@ use std::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use rustix::{
-    fs::{major, minor, mkdirat, openat, stat, symlink, Mode, OFlags, CWD},
+    fs::{CWD, Mode, OFlags, major, minor, mkdirat, openat, stat, symlink},
     io::Errno,
     mount::{
-        fsconfig_create, fsconfig_set_string, fsmount, open_tree, unmount, FsMountFlags,
-        MountAttrFlags, OpenTreeFlags, UnmountFlags,
+        FsMountFlags, MountAttrFlags, OpenTreeFlags, UnmountFlags, fsconfig_create,
+        fsconfig_set_string, fsmount, open_tree, unmount,
     },
     path,
 };

--- a/crates/initramfs/src/main.rs
+++ b/crates/initramfs/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 
-use bootc_initramfs_setup::{gpt_workaround, setup_root, Args};
+use bootc_initramfs_setup::{Args, gpt_workaround, setup_root};
 use clap::Parser;
 
 fn main() -> Result<()> {

--- a/crates/kernel_cmdline/Cargo.toml
+++ b/crates/kernel_cmdline/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc-kernel-cmdline"
 description = "Kernel command line parsing utilities for bootc"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bootc-dev/bootc"
 

--- a/crates/kernel_cmdline/src/bytes.rs
+++ b/crates/kernel_cmdline/src/bytes.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::ops::Deref;
 
-use crate::{utf8, Action};
+use crate::{Action, utf8};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -842,15 +842,17 @@ mod tests {
 
         // Test key without value should fail
         let err = kargs.require_value_of("switch").unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to find kernel argument 'switch'"));
+        assert!(
+            err.to_string()
+                .contains("Failed to find kernel argument 'switch'")
+        );
 
         // Test non-existent key should fail
         let err = kargs.require_value_of("missing").unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to find kernel argument 'missing'"));
+        assert!(
+            err.to_string()
+                .contains("Failed to find kernel argument 'missing'")
+        );
 
         // Test dash/underscore equivalence
         let kargs = Cmdline::from(b"dash-key=value1 under_key=value2".as_slice());

--- a/crates/kernel_cmdline/src/utf8.rs
+++ b/crates/kernel_cmdline/src/utf8.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Deref;
 
-use crate::{bytes, Action};
+use crate::{Action, bytes};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -697,15 +697,17 @@ mod tests {
 
         // Test key without value should fail
         let err = kargs.require_value_of("switch").unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to find kernel argument 'switch'"));
+        assert!(
+            err.to_string()
+                .contains("Failed to find kernel argument 'switch'")
+        );
 
         // Test non-existent key should fail
         let err = kargs.require_value_of("missing").unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to find kernel argument 'missing'"));
+        assert!(
+            err.to_string()
+                .contains("Failed to find kernel argument 'missing'")
+        );
 
         // Test dash/underscore equivalence
         let kargs = Cmdline::from("dash-key=value1 under_key=value2");

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "bootc implementation"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "bootc-lib"
 repository = "https://github.com/bootc-dev/bootc"
@@ -8,7 +8,7 @@ repository = "https://github.com/bootc-dev/bootc"
 # project isn't actually published as a crate.
 version = "1.12.0"
 # In general we try to keep this pinned to what's in the latest RHEL9.
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 include = ["/src", "LICENSE-APACHE", "LICENSE-MIT"]
 

--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -66,7 +66,7 @@ use std::fs::create_dir_all;
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use bootc_blockdev::find_parent_devices;
 use bootc_kernel_cmdline::utf8::{Cmdline, Parameter};
 use bootc_mount::inspect_filesystem_of_dir;
@@ -79,8 +79,8 @@ use cap_std_ext::{
 use clap::ValueEnum;
 use composefs::fs::read_file;
 use composefs::tree::RegularFile;
-use composefs_boot::bootloader::{PEType, EFI_ADDON_DIR_EXT, EFI_ADDON_FILE_EXT, EFI_EXT};
 use composefs_boot::BootOps;
+use composefs_boot::bootloader::{EFI_ADDON_DIR_EXT, EFI_ADDON_FILE_EXT, EFI_EXT, PEType};
 use fn_error_context::context;
 use ostree_ext::composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
 use ostree_ext::composefs_boot::bootloader::UsrLibModulesVmlinuz;
@@ -699,10 +699,12 @@ pub(crate) fn setup_composefs_bls_boot(
                                 .join(&shared_entry)
                                 .join(VMLINUZ);
 
-                            *initrd = vec![entry_paths
-                                .abs_entries_path
-                                .join(&shared_entry)
-                                .join(INITRD)];
+                            *initrd = vec![
+                                entry_paths
+                                    .abs_entries_path
+                                    .join(&shared_entry)
+                                    .join(INITRD),
+                            ];
                         }
 
                         _ => unreachable!(),

--- a/crates/lib/src/bootc_composefs/delete.rs
+++ b/crates/lib/src/bootc_composefs/delete.rs
@@ -7,7 +7,7 @@ use composefs_boot::bootloader::{EFI_ADDON_DIR_EXT, EFI_EXT};
 
 use crate::{
     bootc_composefs::{
-        boot::{find_vmlinuz_initrd_duplicates, get_efi_uuid_source, BootType, SYSTEMD_UKI_DIR},
+        boot::{BootType, SYSTEMD_UKI_DIR, find_vmlinuz_initrd_duplicates, get_efi_uuid_source},
         gc::composefs_gc,
         repo::open_composefs_repo,
         rollback::{composefs_rollback, rename_exchange_user_cfg},
@@ -17,7 +17,7 @@ use crate::{
         COMPOSEFS_STAGED_DEPLOYMENT_FNAME, COMPOSEFS_TRANSIENT_STATE_DIR, STATE_DIR_RELATIVE,
         TYPE1_ENT_PATH, TYPE1_ENT_PATH_STAGED, USER_CFG_STAGED,
     },
-    parsers::bls_config::{parse_bls_config, BLSConfigType},
+    parsers::bls_config::{BLSConfigType, parse_bls_config},
     spec::{BootEntry, Bootloader, DeploymentEntry},
     status::Slot,
     store::{BootedComposefs, Storage},

--- a/crates/lib/src/bootc_composefs/export.rs
+++ b/crates/lib/src/bootc_composefs/export.rs
@@ -3,7 +3,7 @@ use std::{fs::File, os::fd::AsRawFd};
 use anyhow::{Context, Result};
 use cap_std_ext::cap_std::{ambient_authority, fs::Dir};
 use composefs::splitstream::SplitStreamData;
-use ocidir::{oci_spec::image::Platform, OciDir};
+use ocidir::{OciDir, oci_spec::image::Platform};
 use ostree_ext::container::skopeo;
 use ostree_ext::{container::Transport, oci_spec::image::ImageConfiguration};
 use tar::EntryType;

--- a/crates/lib/src/bootc_composefs/repo.rs
+++ b/crates/lib/src/bootc_composefs/repo.rs
@@ -7,7 +7,7 @@ use ostree_ext::composefs::{
     fsverity::{FsVerityHashValue, Sha512HashValue},
     util::Sha256Digest,
 };
-use ostree_ext::composefs_boot::{bootloader::BootEntry as ComposefsBootEntry, BootOps};
+use ostree_ext::composefs_boot::{BootOps, bootloader::BootEntry as ComposefsBootEntry};
 use ostree_ext::composefs_oci::{
     image::create_filesystem as create_composefs_filesystem, pull as composefs_oci_pull,
 };

--- a/crates/lib/src/bootc_composefs/rollback.rs
+++ b/crates/lib/src/bootc_composefs/rollback.rs
@@ -1,14 +1,14 @@
 use std::io::Write;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
-use rustix::fs::{fsync, renameat_with, AtFlags, RenameFlags};
+use rustix::fs::{AtFlags, RenameFlags, fsync, renameat_with};
 
 use crate::bootc_composefs::boot::{
-    primary_sort_key, secondary_sort_key, type1_entry_conf_file_name, BootType,
-    FILENAME_PRIORITY_PRIMARY, FILENAME_PRIORITY_SECONDARY,
+    BootType, FILENAME_PRIORITY_PRIMARY, FILENAME_PRIORITY_SECONDARY, primary_sort_key,
+    secondary_sort_key, type1_entry_conf_file_name,
 };
 use crate::bootc_composefs::status::{get_composefs_status, get_sorted_type1_boot_entries};
 use crate::composefs_consts::TYPE1_ENT_PATH_STAGED;

--- a/crates/lib/src/bootc_composefs/soft_reboot.rs
+++ b/crates/lib/src/bootc_composefs/soft_reboot.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::{Context, Result};
 use bootc_initramfs_setup::setup_root;
 use bootc_kernel_cmdline::utf8::Cmdline;
-use bootc_mount::{bind_mount_from_pidns, PID1};
+use bootc_mount::{PID1, bind_mount_from_pidns};
 use camino::Utf8Path;
 use fn_error_context::context;
 use ostree_ext::systemd_has_soft_reboot;

--- a/crates/lib/src/bootc_composefs/state.rs
+++ b/crates/lib/src/bootc_composefs/state.rs
@@ -17,13 +17,13 @@ use fn_error_context::context;
 
 use ostree_ext::container::deploy::ORIGIN_CONTAINER;
 use rustix::{
-    fs::{open, Mode, OFlags},
+    fs::{Mode, OFlags, open},
     path::Arg,
 };
 
 use crate::bootc_composefs::boot::BootType;
 use crate::bootc_composefs::repo::get_imgref;
-use crate::bootc_composefs::status::{get_sorted_type1_boot_entries, ImgConfigManifest};
+use crate::bootc_composefs::status::{ImgConfigManifest, get_sorted_type1_boot_entries};
 use crate::parsers::bls_config::BLSConfigType;
 use crate::store::{BootedComposefs, Storage};
 use crate::{

--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -17,12 +17,12 @@ use crate::{
     },
     install::EFI_LOADER_INFO,
     parsers::{
-        bls_config::{parse_bls_config, BLSConfig, BLSConfigType},
-        grub_menuconfig::{parse_grub_menuentry_file, MenuEntry},
+        bls_config::{BLSConfig, BLSConfigType, parse_bls_config},
+        grub_menuconfig::{MenuEntry, parse_grub_menuentry_file},
     },
     spec::{BootEntry, BootOrder, Host, HostSpec, ImageReference, ImageStatus},
     store::Storage,
-    utils::{read_uefi_var, EfiError},
+    utils::{EfiError, read_uefi_var},
 };
 
 use std::str::FromStr;

--- a/crates/lib/src/bootc_composefs/switch.rs
+++ b/crates/lib/src/bootc_composefs/switch.rs
@@ -5,9 +5,9 @@ use crate::{
     bootc_composefs::{
         state::update_target_imgref_in_origin,
         status::get_composefs_status,
-        update::{do_upgrade, is_image_pulled, validate_update, DoUpgradeOpts, UpdateAction},
+        update::{DoUpgradeOpts, UpdateAction, do_upgrade, is_image_pulled, validate_update},
     },
-    cli::{imgref_for_switch, SwitchOpts},
+    cli::{SwitchOpts, imgref_for_switch},
     store::{BootedComposefs, Storage},
 };
 

--- a/crates/lib/src/bootc_composefs/update.rs
+++ b/crates/lib/src/bootc_composefs/update.rs
@@ -3,7 +3,7 @@ use camino::Utf8PathBuf;
 use cap_std_ext::cap_std::fs::Dir;
 use composefs::{
     fsverity::{FsVerityHashValue, Sha512HashValue},
-    util::{parse_sha256, Sha256Digest},
+    util::{Sha256Digest, parse_sha256},
 };
 use composefs_boot::BootOps;
 use composefs_oci::image::create_filesystem;
@@ -12,14 +12,14 @@ use ostree_ext::container::ManifestDiff;
 
 use crate::{
     bootc_composefs::{
-        boot::{setup_composefs_bls_boot, setup_composefs_uki_boot, BootSetupType, BootType},
+        boot::{BootSetupType, BootType, setup_composefs_bls_boot, setup_composefs_uki_boot},
         repo::{get_imgref, pull_composefs_repo},
         service::start_finalize_stated_svc,
         soft_reboot::prepare_soft_reboot_composefs,
         state::write_composefs_state,
         status::{
-            get_bootloader, get_composefs_status, get_container_manifest_and_config, get_imginfo,
-            ImgConfigManifest,
+            ImgConfigManifest, get_bootloader, get_composefs_status,
+            get_container_manifest_and_config, get_imginfo,
         },
     },
     cli::{SoftRebootMode, UpgradeOpts},

--- a/crates/lib/src/bootc_composefs/utils.rs
+++ b/crates/lib/src/bootc_composefs/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     bootc_composefs::{
-        boot::{compute_boot_digest_uki, SYSTEMD_UKI_DIR},
+        boot::{SYSTEMD_UKI_DIR, compute_boot_digest_uki},
         state::update_boot_digest_in_origin,
     },
     store::Storage,

--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -1,7 +1,7 @@
 use std::fs::create_dir_all;
 use std::process::Command;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use bootc_utils::CommandRunExt;
 use camino::Utf8Path;
 use cap_std_ext::cap_std::fs::Dir;
@@ -11,7 +11,7 @@ use fn_error_context::context;
 use bootc_blockdev::{Partition, PartitionTable};
 use bootc_mount as mount;
 
-use crate::bootc_composefs::boot::{get_sysroot_parent_dev, mount_esp, SecurebootKeys};
+use crate::bootc_composefs::boot::{SecurebootKeys, get_sysroot_parent_dev, mount_esp};
 use crate::{discoverable_partition_specification, utils};
 
 /// The name of the mountpoint for efi (as a subdirectory of /boot, or at the toplevel)

--- a/crates/lib/src/cfsctl.rs
+++ b/crates/lib/src/cfsctl.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsString,
-    fs::{create_dir_all, File},
+    fs::{File, create_dir_all},
     io::BufWriter,
     path::{Path, PathBuf},
     sync::Arc,
@@ -12,7 +12,7 @@ use clap::{Parser, Subcommand};
 
 use rustix::fs::CWD;
 
-use composefs_boot::{write_boot, BootOps};
+use composefs_boot::{BootOps, write_boot};
 
 use composefs::{
     dumpfile,

--- a/crates/lib/src/deploy.rs
+++ b/crates/lib/src/deploy.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::io::{BufRead, Write};
 use std::process::Command;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use bootc_kernel_cmdline::utf8::CmdlineOwned;
 use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;

--- a/crates/lib/src/generator.rs
+++ b/crates/lib/src/generator.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use cap_std::fs::Dir;
 use cap_std_ext::{cap_std, dirext::CapStdExtDirExt};
 use fn_error_context::context;
-use ostree_ext::container_utils::{is_ostree_booted_in, OSTREE_BOOTED};
+use ostree_ext::container_utils::{OSTREE_BOOTED, is_ostree_booted_in};
 use rustix::{fd::AsFd, fs::StatVfsMountFlags};
 
 use crate::install::DESTRUCTIVE_CLEANUP;
@@ -182,10 +182,12 @@ mod tests {
         unit_enablement_impl(sysroot, &unit_dir).unwrap();
         let wantsdir = &unit_dir.open_dir("multi-user.target.wants")?;
         verify(wantsdir, 2)?;
-        assert!(wantsdir
-            .symlink_metadata_optional(CLEANUP_UNIT)
-            .unwrap()
-            .is_none());
+        assert!(
+            wantsdir
+                .symlink_metadata_optional(CLEANUP_UNIT)
+                .unwrap()
+                .is_none()
+        );
 
         // Now create sysroot and rerun the generator
         unit_enablement_impl(sysroot, &unit_dir).unwrap();
@@ -200,10 +202,12 @@ mod tests {
         verify(wantsdir, 3)?;
 
         // And now the unit should be enabled
-        assert!(wantsdir
-            .symlink_metadata(CLEANUP_UNIT)
-            .unwrap()
-            .is_symlink());
+        assert!(
+            wantsdir
+                .symlink_metadata(CLEANUP_UNIT)
+                .unwrap()
+                .is_symlink()
+        );
 
         Ok(())
     }

--- a/crates/lib/src/image.rs
+++ b/crates/lib/src/image.rs
@@ -2,11 +2,11 @@
 //!
 //! APIs for operating on container images in the bootc storage.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bootc_utils::CommandRunExt;
 use cap_std_ext::cap_std::{self, fs::Dir};
 use clap::ValueEnum;
-use comfy_table::{presets::NOTHING, Table};
+use comfy_table::{Table, presets::NOTHING};
 use fn_error_context::context;
 use ostree_ext::container::{ImageReference, Transport};
 use serde::Serialize;

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aleph::InstallAleph;
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{Context, Result, anyhow, ensure};
 use bootc_kernel_cmdline::utf8::{Cmdline, CmdlineOwned};
 use bootc_utils::CommandRunExt;
 use camino::Utf8Path;
@@ -45,7 +45,7 @@ use ostree::gio;
 use ostree_ext::ostree;
 use ostree_ext::ostree_prepareroot::{ComposefsState, Tristate};
 use ostree_ext::prelude::Cast;
-use ostree_ext::sysroot::{allocate_new_stateroot, list_stateroots, SysrootLock};
+use ostree_ext::sysroot::{SysrootLock, allocate_new_stateroot, list_stateroots};
 use ostree_ext::{container as ostree_container, ostree_prepareroot};
 #[cfg(feature = "install-to-disk")]
 use rustix::fs::FileTypeExt;
@@ -58,7 +58,7 @@ use crate::bootc_composefs::{boot::setup_composefs_boot, repo::initialize_compos
 use crate::boundimage::{BoundImage, ResolvedBoundImage};
 use crate::containerenv::ContainerExecutionInfo;
 use crate::deploy::{
-    prepare_for_pull, pull_from_prepared, MergeState, PreparedImportMeta, PreparedPullResult,
+    MergeState, PreparedImportMeta, PreparedPullResult, prepare_for_pull, pull_from_prepared,
 };
 use crate::lsm;
 use crate::progress_jsonl::ProgressWriter;
@@ -66,7 +66,7 @@ use crate::spec::{Bootloader, ImageReference};
 use crate::store::Storage;
 use crate::task::Task;
 use crate::utils::sigpolicy_from_opt;
-use bootc_kernel_cmdline::{bytes, utf8, INITRD_ARG_PREFIX, ROOTFLAGS};
+use bootc_kernel_cmdline::{INITRD_ARG_PREFIX, ROOTFLAGS, bytes, utf8};
 use bootc_mount::Filesystem;
 use composefs::fsverity::FsVerityHashValue;
 
@@ -1277,7 +1277,10 @@ fn require_host_userns() -> Result<()> {
         .uid();
     // We must really be in a rootless container, or in some way
     // we're not part of the host user namespace.
-    ensure!(pid1_uid == 0, "{proc1} is owned by {pid1_uid}, not zero; this command must be run in the root user namespace (e.g. not rootless podman)");
+    ensure!(
+        pid1_uid == 0,
+        "{proc1} is owned by {pid1_uid}, not zero; this command must be run in the root user namespace (e.g. not rootless podman)"
+    );
     tracing::trace!("OK: we're in a matching user namespace with pid1");
     Ok(())
 }
@@ -1369,7 +1372,10 @@ async fn prepare_install(
     let external_source = source_opts.source_imgref.is_some();
     let (source, target_rootfs) = match source_opts.source_imgref {
         None => {
-            ensure!(host_is_container, "Either --source-imgref must be defined or this command must be executed inside a podman container.");
+            ensure!(
+                host_is_container,
+                "Either --source-imgref must be defined or this command must be executed inside a podman container."
+            );
 
             crate::cli::require_root(true)?;
 

--- a/crates/lib/src/install/baseline.rs
+++ b/crates/lib/src/install/baseline.rs
@@ -23,12 +23,12 @@ use clap::ValueEnum;
 use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 
-use super::config::Filesystem;
 use super::MountSpec;
-use super::RootSetup;
-use super::State;
 use super::RUN_BOOTC;
 use super::RW_KARG;
+use super::RootSetup;
+use super::State;
+use super::config::Filesystem;
 use crate::task::Task;
 use bootc_kernel_cmdline::utf8::Cmdline;
 #[cfg(feature = "install-to-disk")]

--- a/crates/lib/src/install/osconfig.rs
+++ b/crates/lib/src/install/osconfig.rs
@@ -66,9 +66,9 @@ mod tests {
 
         let content = root.read_to_string(format!("etc/tmpfiles.d/{ROOT_SSH_TMPFILE}"))?;
         assert_eq!(
-        content,
-        "f~ /var/roothome/.ssh/authorized_keys 600 root root - c3NoLWVkMjU1MTkgQUJDREUgZXhhbXBsZUBkZW1vCg==\n"
-    );
+            content,
+            "f~ /var/roothome/.ssh/authorized_keys 600 root root - c3NoLWVkMjU1MTkgQUJDREUgZXhhbXBsZUBkZW1vCg==\n"
+        );
 
         Ok(())
     }
@@ -83,9 +83,9 @@ mod tests {
 
         let content = root.read_to_string(format!("etc/tmpfiles.d/{ROOT_SSH_TMPFILE}"))?;
         assert_eq!(
-        content,
-        "f~ /root/.ssh/authorized_keys 600 root root - c3NoLWVkMjU1MTkgQUJDREUgZXhhbXBsZUBkZW1vCg==\n"
-    );
+            content,
+            "f~ /root/.ssh/authorized_keys 600 root root - c3NoLWVkMjU1MTkgQUJDREUgZXhhbXBsZUBkZW1vCg==\n"
+        );
         Ok(())
     }
 }

--- a/crates/lib/src/lints.rs
+++ b/crates/lib/src/lints.rs
@@ -427,7 +427,9 @@ fn check_buildah_injected(root: &Dir, _config: &LintExecutionConfig) -> LintResu
     for ent in RUNTIME_INJECTED {
         if let Some(meta) = root.symlink_metadata_optional(ent)? {
             if meta.is_file() && meta.size() == 0 {
-                return lint_err(format!("/{ent} is an empty file; this may have been synthesized by a container runtime."));
+                return lint_err(format!(
+                    "/{ent} is an empty file; this may have been synthesized by a container runtime."
+                ));
             }
         }
     }
@@ -453,7 +455,7 @@ fn check_usretc(root: &Dir, _config: &LintExecutionConfig) -> LintResult {
     // But having both /etc and /usr/etc is not something we want to support.
     if root.symlink_metadata_optional("usr/etc")?.is_some() {
         return lint_err(
-            "Found /usr/etc - this is a bootc implementation detail and not supported to use in containers"
+            "Found /usr/etc - this is a bootc implementation detail and not supported to use in containers",
         );
     }
     lint_ok()
@@ -1195,7 +1197,10 @@ mod tests {
         // Test case 4: Iterator with items > DEFAULT_TRUNCATED_OUTPUT
         let items_multiple = (1..=8).map(|v| format!("item{v}")).collect::<Vec<_>>();
         format_items(&config, header, items_multiple.iter(), &mut output_str)?;
-        assert_eq!(output_str, "Test Header:\n  item1\n  item2\n  item3\n  item4\n  item5\n  item6\n  item7\n  item8\n");
+        assert_eq!(
+            output_str,
+            "Test Header:\n  item1\n  item2\n  item3\n  item4\n  item5\n  item6\n  item7\n  item8\n"
+        );
         output_str.clear();
 
         Ok(())

--- a/crates/lib/src/lsm.rs
+++ b/crates/lib/src/lsm.rs
@@ -167,7 +167,9 @@ pub(crate) fn selinux_ensure_install_or_setenforce() -> Result<Option<SetEnforce
         Some(SetEnforceGuard::new())
     } else {
         let current = get_current_security_context()?;
-        anyhow::bail!("Failed to enter install_t (running as {current}) - use BOOTC_SETENFORCE0_FALLBACK=1 to override");
+        anyhow::bail!(
+            "Failed to enter install_t (running as {current}) - use BOOTC_SETENFORCE0_FALLBACK=1 to override"
+        );
     };
     Ok(g)
 }

--- a/crates/lib/src/parsers/bls_config.rs
+++ b/crates/lib/src/parsers/bls_config.rs
@@ -4,7 +4,7 @@
 
 #![allow(dead_code)]
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use bootc_kernel_cmdline::utf8::{Cmdline, CmdlineOwned};
 use camino::Utf8PathBuf;
 use composefs_boot::bootloader::EFI_EXT;
@@ -316,9 +316,20 @@ mod tests {
             Some("Fedora 42.20250623.3.1 (CoreOS)".to_string())
         );
         assert_eq!(config.version, "2");
-        assert_eq!(linux, "/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/vmlinuz-5.14.10");
-        assert_eq!(initrd, vec!["/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/initramfs-5.14.10.img"]);
-        assert_eq!(&*options.unwrap(), "root=UUID=abc123 rw composefs=7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6");
+        assert_eq!(
+            linux,
+            "/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/vmlinuz-5.14.10"
+        );
+        assert_eq!(
+            initrd,
+            vec![
+                "/boot/7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6/initramfs-5.14.10.img"
+            ]
+        );
+        assert_eq!(
+            &*options.unwrap(),
+            "root=UUID=abc123 rw composefs=7e11ac46e3e022053e7226a20104ac656bf72d1a84e3a398b7cce70e9df188b6"
+        );
         assert_eq!(config.extra.get("custom1"), Some(&"value1".to_string()));
         assert_eq!(config.extra.get("custom2"), Some(&"value2".to_string()));
 

--- a/crates/lib/src/parsers/grub_menuconfig.rs
+++ b/crates/lib/src/parsers/grub_menuconfig.rs
@@ -8,11 +8,11 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use composefs_boot::bootloader::EFI_EXT;
 use nom::{
+    Err, IResult, Parser,
     bytes::complete::{escaped, tag, take_until},
     character::complete::{multispace0, multispace1, none_of},
     error::{Error, ErrorKind, ParseError},
     sequence::delimited,
-    Err, IResult, Parser,
 };
 
 /// Body content of a GRUB menuentry containing parsed commands.

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -35,7 +35,7 @@ use ostree_ext::{gio, ostree};
 use rustix::fs::Mode;
 
 use crate::bootc_composefs::boot::{get_esp_partition, get_sysroot_parent_dev, mount_esp};
-use crate::bootc_composefs::status::{composefs_booted, get_bootloader, ComposefsCmdline};
+use crate::bootc_composefs::status::{ComposefsCmdline, composefs_booted, get_bootloader};
 use crate::lsm;
 use crate::podstorage::CStorage;
 use crate::spec::{Bootloader, ImageStatus};

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Internal mount code"
 # Should never be published to crates.io
 publish = false
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "bootc-mount"
 repository = "https://github.com/bootc-dev/bootc"

--- a/crates/mount/src/mount.rs
+++ b/crates/mount/src/mount.rs
@@ -7,7 +7,7 @@ use std::{
     process::Command,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use bootc_utils::CommandRunExt;
 use camino::Utf8Path;
 use cap_std_ext::{cap_std::fs::Dir, cmdext::CapStdExtCommandExt};

--- a/crates/mount/src/tempmount.rs
+++ b/crates/mount/src/tempmount.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std_ext::cap_std::{ambient_authority, fs::Dir};
 use fn_error_context::context;
-use rustix::mount::{move_mount, unmount, MountFlags, MoveMountFlags, UnmountFlags};
+use rustix::mount::{MountFlags, MoveMountFlags, UnmountFlags, move_mount, unmount};
 
 pub struct TempMount {
     pub dir: tempfile::TempDir,

--- a/crates/ostree-ext/Cargo.toml
+++ b/crates/ostree-ext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Colin Walters <walters@verbum.org>"]
 description = "Extension APIs for OSTree"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 repository = "https://github.com/ostreedev/ostree-rs-ext"

--- a/crates/ostree-ext/src/container/deploy.rs
+++ b/crates/ostree-ext/src/container/deploy.rs
@@ -5,7 +5,7 @@ use fn_error_context::context;
 use ostree::glib;
 use std::collections::HashSet;
 
-use super::store::{gc_image_layers, LayeredImageState};
+use super::store::{LayeredImageState, gc_image_layers};
 use super::{ImageReference, OstreeImageReference};
 use crate::container::store::PrepareResult;
 use crate::keyfileext::KeyFileExt;

--- a/crates/ostree-ext/src/container/encapsulate.rs
+++ b/crates/ostree-ext/src/container/encapsulate.rs
@@ -1,12 +1,12 @@
 //! APIs for creating container images from OSTree commits
 
-use super::{ImageReference, SignatureSource, OSTREE_COMMIT_LABEL};
-use super::{OstreeImageReference, Transport, COMPONENT_SEPARATOR, CONTENT_ANNOTATION};
+use super::{COMPONENT_SEPARATOR, CONTENT_ANNOTATION, OstreeImageReference, Transport};
+use super::{ImageReference, OSTREE_COMMIT_LABEL, SignatureSource};
 use crate::chunking::{Chunk, Chunking, ObjectMetaSized};
 use crate::container::skopeo;
 use crate::objectsource::ContentID;
 use crate::tar as ostree_tar;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;

--- a/crates/ostree-ext/src/container/store.rs
+++ b/crates/ostree-ext/src/container/store.rs
@@ -11,7 +11,7 @@ use crate::generic_decompress::Decompressor;
 use crate::logging::system_repo_journal_print;
 use crate::refescape;
 use crate::sysroot::SysrootLock;
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use bootc_utils::ResultExt;
 use camino::{Utf8Path, Utf8PathBuf};
 use canon_json::CanonJsonSerialize;
@@ -692,7 +692,9 @@ impl ImageImporter {
     pub(crate) async fn prepare_internal(&mut self, verify_layers: bool) -> Result<PrepareResult> {
         match &self.imgref.sigverify {
             SignatureSource::ContainerPolicy if skopeo::container_policy_is_default_insecure()? => {
-                return Err(anyhow!("containers-policy.json specifies a default of `insecureAcceptAnything`; refusing usage"));
+                return Err(anyhow!(
+                    "containers-policy.json specifies a default of `insecureAcceptAnything`; refusing usage"
+                ));
             }
             SignatureSource::OstreeRemote(_) if verify_layers => {
                 return Err(anyhow!(
@@ -795,7 +797,9 @@ impl ImageImporter {
         if matches!(self.imgref.sigverify, SignatureSource::ContainerPolicy)
             && skopeo::container_policy_is_default_insecure()?
         {
-            return Err(anyhow!("containers-policy.json specifies a default of `insecureAcceptAnything`; refusing usage"));
+            return Err(anyhow!(
+                "containers-policy.json specifies a default of `insecureAcceptAnything`; refusing usage"
+            ));
         }
         let remote = match &self.imgref.sigverify {
             SignatureSource::OstreeRemote(remote) => Some(remote.clone()),
@@ -2070,7 +2074,10 @@ mod tests {
             )
             .build()
             .unwrap();
-        assert_eq!(ref_for_layer(&d).unwrap(), "ostree/container/blob/sha256_3A_2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae");
+        assert_eq!(
+            ref_for_layer(&d).unwrap(),
+            "ostree/container/blob/sha256_3A_2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+        );
     }
 
     #[test]

--- a/crates/ostree-ext/src/container/update_detachedmeta.rs
+++ b/crates/ostree-ext/src/container/update_detachedmeta.rs
@@ -1,7 +1,7 @@
 use super::ImageReference;
-use crate::container::{skopeo, DIFFID_LABEL};
-use crate::container::{store as container_store, Transport};
-use anyhow::{anyhow, Context, Result};
+use crate::container::{DIFFID_LABEL, skopeo};
+use crate::container::{Transport, store as container_store};
+use anyhow::{Context, Result, anyhow};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;

--- a/crates/ostree-ext/src/fixture.rs
+++ b/crates/ostree-ext/src/fixture.rs
@@ -10,7 +10,7 @@ use crate::objgv::gv_dirtree;
 use crate::prelude::*;
 use crate::tar::SECURITY_SELINUX_XATTR_C;
 use crate::{gio, glib};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use bootc_utils::CommandRunExt;
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use cap_std::fs::Dir;
@@ -625,9 +625,11 @@ impl Fixture {
             store::ImageImporter::new(self.destrepo(), &ostree_imgref, Default::default())
                 .await
                 .unwrap();
-        assert!(store::query_image(self.destrepo(), &imgref)
-            .unwrap()
-            .is_none());
+        assert!(
+            store::query_image(self.destrepo(), &imgref)
+                .unwrap()
+                .is_none()
+        );
         let prep = match imp.prepare().await.context("Init prep derived")? {
             store::PrepareResult::AlreadyPresent(_) => panic!("should not be already imported"),
             store::PrepareResult::Ready(r) => r,
@@ -1053,9 +1055,11 @@ impl NonOstreeFixture {
             store::ImageImporter::new(self.destrepo(), &ostree_imgref, Default::default())
                 .await
                 .unwrap();
-        assert!(store::query_image(self.destrepo(), &imgref)
-            .unwrap()
-            .is_none());
+        assert!(
+            store::query_image(self.destrepo(), &imgref)
+                .unwrap()
+                .is_none()
+        );
         let prep = match imp.prepare().await.context("Init prep derived")? {
             store::PrepareResult::AlreadyPresent(_) => panic!("should not be already imported"),
             store::PrepareResult::Ready(r) => r,

--- a/crates/ostree-ext/src/globals.rs
+++ b/crates/ostree-ext/src/globals.rs
@@ -3,8 +3,8 @@
 use super::Result;
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::RootDir;
+use cap_std_ext::cap_std::fs::Dir;
 use fn_error_context::context;
 use ostree::glib;
 use std::fs::File;

--- a/crates/ostree-ext/src/ima.rs
+++ b/crates/ostree-ext/src/ima.rs
@@ -10,7 +10,7 @@ use gio::glib;
 use gio::prelude::*;
 use glib::Variant;
 use gvariant::aligned_bytes::TryAsAligned;
-use gvariant::{gv, Marker, Structure};
+use gvariant::{Marker, Structure, gv};
 use ostree::gio;
 use rustix::fd::BorrowedFd;
 use std::collections::{BTreeMap, HashMap};

--- a/crates/ostree-ext/src/integrationtest.rs
+++ b/crates/ostree-ext/src/integrationtest.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use crate::container_utils::{is_ostree_container, ostree_booted};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
@@ -13,8 +13,8 @@ use fn_error_context::context;
 use gio::prelude::*;
 use oci_spec::image as oci_image;
 use ocidir::{
-    oci_spec::image::{Arch, Platform},
     LayerWriter,
+    oci_spec::image::{Arch, Platform},
 };
 use ostree::gio;
 use xshell::cmd;
@@ -164,7 +164,7 @@ pub(crate) async fn create_fixture() -> Result<()> {
 
 pub(crate) fn test_ima() -> Result<()> {
     use gvariant::aligned_bytes::TryAsAligned;
-    use gvariant::{gv, Marker, Structure};
+    use gvariant::{Marker, Structure, gv};
 
     let cancellable = gio::Cancellable::NONE;
     let fixture = crate::fixture::Fixture::new_v1()?;

--- a/crates/ostree-ext/src/objgv.rs
+++ b/crates/ostree-ext/src/objgv.rs
@@ -16,8 +16,8 @@ pub(crate) use gv_dirtree;
 
 #[cfg(test)]
 mod tests {
-    use gvariant::aligned_bytes::TryAsAligned;
     use gvariant::Marker;
+    use gvariant::aligned_bytes::TryAsAligned;
 
     #[test]
     fn test_dirtree() {

--- a/crates/ostree-ext/src/refescape.rs
+++ b/crates/ostree-ext/src/refescape.rs
@@ -142,7 +142,7 @@ pub fn unprefix_unescape_ref(prefix: &str, ostree_ref: &str) -> Result<String> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use quickcheck::{quickcheck, TestResult};
+    use quickcheck::{TestResult, quickcheck};
 
     const TESTPREFIX: &str = "testprefix/blah";
 

--- a/crates/ostree-ext/src/repair.rs
+++ b/crates/ostree-ext/src/repair.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cap_std::fs::{Dir, MetadataExt};
 use cap_std_ext::cap_std;
 use fn_error_context::context;

--- a/crates/ostree-ext/src/tar/export.rs
+++ b/crates/ostree-ext/src/tar/export.rs
@@ -2,7 +2,7 @@
 
 use crate::chunking;
 use crate::objgv::*;
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{Context, Result, anyhow, ensure};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use gio::glib;

--- a/crates/ostree-ext/src/tar/import.rs
+++ b/crates/ostree-ext/src/tar/import.rs
@@ -1,7 +1,7 @@
 //! APIs for extracting OSTree commits from container images
 
 use crate::Result;
-use anyhow::{anyhow, bail, ensure, Context};
+use anyhow::{Context, anyhow, bail, ensure};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use fn_error_context::context;
@@ -12,7 +12,7 @@ use ostree::gio;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::io::prelude::*;
-use tracing::{event, instrument, Level};
+use tracing::{Level, event, instrument};
 
 /// Arbitrary limit on xattrs to avoid RAM exhaustion attacks. The actual filesystem limits are often much smaller.
 // See https://en.wikipedia.org/wiki/Extended_file_attributes
@@ -894,8 +894,7 @@ mod tests {
 
     #[test]
     fn test_parse_object_entry_path() {
-        let path =
-            "sysroot/ostree/repo/objects/b8/627e3ef0f255a322d2bd9610cfaaacc8f122b7f8d17c0e7e3caafa160f9fc7.file.xattrs";
+        let path = "sysroot/ostree/repo/objects/b8/627e3ef0f255a322d2bd9610cfaaacc8f122b7f8d17c0e7e3caafa160f9fc7.file.xattrs";
         let input = Utf8PathBuf::from(path);
         let expected_parent = "b8";
         let expected_rest =

--- a/crates/ostree-ext/src/tar/write.rs
+++ b/crates/ostree-ext/src/tar/write.rs
@@ -7,9 +7,9 @@
 //! In the future, this may also evolve into parsing the tar
 //! stream in Rust, not in C.
 
-use crate::generic_decompress::Decompressor;
 use crate::Result;
-use anyhow::{anyhow, Context};
+use crate::generic_decompress::Decompressor;
+use anyhow::{Context, anyhow};
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 
 use cap_std::io_lifetimes;

--- a/crates/ostree-ext/tests/it/main.rs
+++ b/crates/ostree-ext/tests/it/main.rs
@@ -12,10 +12,10 @@ use oci_spec::image as oci_image;
 use ocidir::oci_spec::distribution::Reference;
 use ocidir::oci_spec::image::{Arch, DigestAlgorithm};
 use ostree_ext::chunking::ObjectMetaSized;
-use ostree_ext::container::{store, ManifestDiff, OSTREE_COMMIT_LABEL};
 use ostree_ext::container::{
     Config, ExportOpts, ImageReference, OstreeImageReference, SignatureSource, Transport,
 };
+use ostree_ext::container::{ManifestDiff, OSTREE_COMMIT_LABEL, store};
 use ostree_ext::prelude::{Cast, FileExt};
 use ostree_ext::tar::TarImportOptions;
 use ostree_ext::{fixture, ostree_manual};
@@ -29,7 +29,7 @@ use std::time::SystemTime;
 use xshell::cmd;
 
 use ostree_ext::fixture::{
-    FileDef, Fixture, NonOstreeFixture, CONTENTS_CHECKSUM_V0, LAYERS_V0_LEN, PKGS_V0_LEN,
+    CONTENTS_CHECKSUM_V0, FileDef, Fixture, LAYERS_V0_LEN, NonOstreeFixture, PKGS_V0_LEN,
 };
 
 const EXAMPLE_TAR_LAYER: &[u8] = include_bytes!("fixtures/hlinks.tar.gz");
@@ -965,11 +965,13 @@ async fn test_unencapsulate_unbootable() -> Result<()> {
     .context("exporting")?;
     assert!(srcoci_path.exists());
 
-    assert!(fixture
-        .destrepo()
-        .resolve_rev(fixture.testref(), true)
-        .unwrap()
-        .is_none());
+    assert!(
+        fixture
+            .destrepo()
+            .resolve_rev(fixture.testref(), true)
+            .unwrap()
+            .is_none()
+    );
 
     let target = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unverified)
         .await
@@ -1098,9 +1100,11 @@ async fn test_container_chunked() -> Result<()> {
 
     let mut imp =
         store::ImageImporter::new(fixture.destrepo(), &imgref, Default::default()).await?;
-    assert!(store::query_image(fixture.destrepo(), &imgref.imgref)
-        .unwrap()
-        .is_none());
+    assert!(
+        store::query_image(fixture.destrepo(), &imgref.imgref)
+            .unwrap()
+            .is_none()
+    );
     let prep = match imp.prepare().await.context("Init prep derived")? {
         store::PrepareResult::AlreadyPresent(_) => panic!("should not be already imported"),
         store::PrepareResult::Ready(r) => r,
@@ -1122,14 +1126,16 @@ async fn test_container_chunked() -> Result<()> {
     assert_eq!(digest, expected_digest);
     {
         let mut layer_history = prep.layers_with_history();
-        assert!(layer_history
-            .next()
-            .unwrap()?
-            .1
-            .created_by()
-            .as_ref()
-            .unwrap()
-            .starts_with("ostree export"));
+        assert!(
+            layer_history
+                .next()
+                .unwrap()?
+                .1
+                .created_by()
+                .as_ref()
+                .unwrap()
+                .starts_with("ostree export")
+        );
         assert_eq!(
             layer_history
                 .next()
@@ -1365,9 +1371,11 @@ async fn test_container_var_content() -> Result<()> {
         ostree_manual::repo_file_read_to_string(&varfile)?,
         junk_var_data
     );
-    assert!(!ostree_root
-        .child("var/lib/foo")
-        .query_exists(gio::Cancellable::NONE));
+    assert!(
+        !ostree_root
+            .child("var/lib/foo")
+            .query_exists(gio::Cancellable::NONE)
+    );
 
     assert!(
         store::image_filtered_content_warning(&import.filtered_files)
@@ -1395,9 +1403,11 @@ async fn test_container_var_content() -> Result<()> {
         .downcast::<ostree::RepoFile>()
         .unwrap();
     assert!(!varfile.query_exists(gio::Cancellable::NONE));
-    assert!(ostree_root
-        .child("var/lib/foo")
-        .query_exists(gio::Cancellable::NONE));
+    assert!(
+        ostree_root
+            .child("var/lib/foo")
+            .query_exists(gio::Cancellable::NONE)
+    );
     Ok(())
 }
 
@@ -1763,13 +1773,15 @@ async fn test_container_write_derive() -> Result<()> {
     )
     .read()?;
     assert_eq!(c.as_str(), "newderivedfile v1");
-    assert!(cmd!(
-        sh,
-        "ostree --repo=dest/repo ls {merge_commit} /usr/bin/newderivedfile3"
-    )
-    .ignore_stderr()
-    .run()
-    .is_err());
+    assert!(
+        cmd!(
+            sh,
+            "ostree --repo=dest/repo ls {merge_commit} /usr/bin/newderivedfile3"
+        )
+        .ignore_stderr()
+        .run()
+        .is_err()
+    );
 
     // And there should be no changes on upgrade again.
     let mut imp =
@@ -1903,7 +1915,9 @@ async fn test_container_write_derive_sysroot_hardlink() -> Result<()> {
         derived_path,
         |w| {
             let mut tar = tar::Builder::new(w);
-            let objpath = Utf8Path::new("sysroot/ostree/repo/objects/60/feb13e826d2f9b62490ab24cea0f4a2d09615fb57027e55f713c18c59f4796.file");
+            let objpath = Utf8Path::new(
+                "sysroot/ostree/repo/objects/60/feb13e826d2f9b62490ab24cea0f4a2d09615fb57027e55f713c18c59f4796.file",
+            );
             let d = objpath.parent().unwrap();
             fn mkparents<F: std::io::Write>(
                 t: &mut tar::Builder<F>,
@@ -2052,14 +2066,15 @@ async fn test_container_xattr() -> Result<()> {
         let v = arping_ostree_xattrs.data_as_bytes();
         let v = v.try_as_aligned().unwrap();
         let v = gvariant::gv!("a(ayay)").cast(v);
-        assert!(v
-            .iter()
-            .find(|entry| {
-                let k = entry.to_tuple().0;
-                let k = std::ffi::CStr::from_bytes_with_nul(k).unwrap();
-                k.to_str().ok() == Some("security.capability")
-            })
-            .is_some());
+        assert!(
+            v.iter()
+                .find(|entry| {
+                    let k = entry.to_tuple().0;
+                    let k = std::ffi::CStr::from_bytes_with_nul(k).unwrap();
+                    k.to_str().ok() == Some("security.capability")
+                })
+                .is_some()
+        );
     }
 
     // Build a derived image

--- a/crates/system-reinstall-bootc/Cargo.toml
+++ b/crates/system-reinstall-bootc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "system-reinstall-bootc"
 version = "0.1.9"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bootc-dev/bootc"
 publish = false
 # For now don't bump this above what is currently shipped in RHEL9.
-rust-version = "1.75.0"
+rust-version = "1.85.0"
 
 # See https://github.com/coreos/cargo-vendor-filterer
 [package.metadata.vendor-filter]

--- a/crates/system-reinstall-bootc/src/main.rs
+++ b/crates/system-reinstall-bootc/src/main.rs
@@ -1,6 +1,6 @@
 //! The main entrypoint for the bootc system reinstallation CLI
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use bootc_utils::CommandRunExt;
 use clap::Parser;
 use fn_error_context::context;
@@ -79,7 +79,9 @@ fn run() -> Result<()> {
     println!("{}", reinstall_podman_command.to_string_pretty());
 
     println!();
-    println!("After reboot, the current root will be available in the /sysroot directory. Existing mounts will not be automatically mounted by the bootc system unless they are defined in the bootc image. Some automatic cleanup of the previous root will be performed.");
+    println!(
+        "After reboot, the current root will be available in the /sysroot directory. Existing mounts will not be automatically mounted by the bootc system unless they are defined in the bootc image. Some automatic cleanup of the previous root will be performed."
+    );
 
     prompt::temporary_developer_protection_prompt()?;
 

--- a/crates/system-reinstall-bootc/src/podman.rs
+++ b/crates/system-reinstall-bootc/src/podman.rs
@@ -1,7 +1,7 @@
-use crate::{prompt, ReinstallOpts};
+use crate::{ReinstallOpts, prompt};
 
 use super::ROOT_KEY_MOUNT_POINT;
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use bootc_utils::CommandRunExt;
 use fn_error_context::context;
 use std::process::Command;
@@ -150,7 +150,10 @@ pub(crate) fn ensure_podman_installed() -> Result<()> {
         return Ok(());
     }
 
-    prompt::ask_yes_no("Podman was not found on this system. It's required in order to install a bootc image. Do you want to install it now?", true)?;
+    prompt::ask_yes_no(
+        "Podman was not found on this system. It's required in order to install a bootc image. Do you want to install it now?",
+        true,
+    )?;
 
     ensure!(
         which(podman_install_script_path()).is_ok(),

--- a/crates/system-reinstall-bootc/src/prompt.rs
+++ b/crates/system-reinstall-bootc/src/prompt.rs
@@ -10,7 +10,7 @@ macro_rules! println_flush {
 }
 
 use crate::{btrfs, lvm, prompt, users::get_all_users_keys};
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use fn_error_context::context;
 
 use crossterm::event::{self, Event};
@@ -127,7 +127,9 @@ pub(crate) fn mount_warning() -> Result<()> {
 
     if !mounts.is_empty() {
         println!();
-        println!("NOTICE: the following mounts are left unchanged by this tool and will not be automatically mounted unless specified in the bootc image. Consult the bootc documentation to determine the appropriate action for your system.");
+        println!(
+            "NOTICE: the following mounts are left unchanged by this tool and will not be automatically mounted unless specified in the bootc image. Consult the bootc documentation to determine the appropriate action for your system."
+        );
         println!();
         for m in mounts {
             println!("{m}");

--- a/crates/sysusers/Cargo.toml
+++ b/crates/sysusers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc-sysusers"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/crates/sysusers/src/nameservice/group.rs
+++ b/crates/sysusers/src/nameservice/group.rs
@@ -1,7 +1,7 @@
 //! Helpers for [user passwd file](https://man7.org/linux/man-pages/man5/passwd.5.html).
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cap_std_ext::cap_std::fs::Dir;
 use std::io::{BufRead, BufReader, Write};
 

--- a/crates/sysusers/src/nameservice/passwd.rs
+++ b/crates/sysusers/src/nameservice/passwd.rs
@@ -1,7 +1,7 @@
 //! Helpers for [password file](https://man7.org/linux/man-pages/man5/passwd.5.html).
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cap_std_ext::{cap_std::fs::Dir, dirext::CapStdExtDirExt};
 use std::io::{BufRead, BufReader, Write};
 

--- a/crates/sysusers/src/nameservice/shadow.rs
+++ b/crates/sysusers/src/nameservice/shadow.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2021 Oracle and/or its affiliates.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::io::{BufRead, Write};
 
 /// Entry from shadow file.

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -3,7 +3,7 @@
 name = "tests-integration"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [[bin]]

--- a/crates/tests-integration/src/container.rs
+++ b/crates/tests-integration/src/container.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use fn_error_context::context;
 use libtest_mimic::Trial;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 fn new_test(description: &'static str, f: fn() -> anyhow::Result<()>) -> libtest_mimic::Trial {
     Trial::test(description, move || f().map_err(Into::into))

--- a/crates/tests-integration/src/install.rs
+++ b/crates/tests-integration/src/install.rs
@@ -7,7 +7,7 @@ use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
 use fn_error_context::context;
 use libtest_mimic::Trial;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 pub(crate) const BASE_ARGS: &[&str] = &["podman", "run", "--rm", "--privileged", "--pid=host"];
 

--- a/crates/tests-integration/src/runvm.rs
+++ b/crates/tests-integration/src/runvm.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Subcommand;
 use fn_error_context::context;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 const BUILDER_ANNOTATION: &str = "bootc.diskimage-builder";
 const TEST_IMAGE: &str = "localhost/bootc";

--- a/crates/tests-integration/src/system_reinstall.rs
+++ b/crates/tests-integration/src/system_reinstall.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use fn_error_context::context;
 use libtest_mimic::Trial;
 use rexpect::session::PtySession;

--- a/crates/tmpfiles/Cargo.toml
+++ b/crates/tmpfiles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc-tmpfiles"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bootc-internal-utils"
 description = "Internal implementation component of bootc; do not use"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bootc-dev/bootc"
 

--- a/crates/utils/src/command.rs
+++ b/crates/utils/src/command.rs
@@ -320,9 +320,10 @@ mod tests {
             .check_status_with_stderr(temp_stderr)
             .err()
             .unwrap();
-        assert!(e
-            .to_string()
-            .contains("Subprocess failed: ExitStatus(unix_wait_status(256))"));
+        assert!(
+            e.to_string()
+                .contains("Subprocess failed: ExitStatus(unix_wait_status(256))")
+        );
         assert!(e.to_string().contains("test error message"));
     }
 
@@ -372,6 +373,9 @@ mod tests {
             "to-existing-root",
         ]);
 
-        similar_asserts::assert_eq!(cmd.to_string_pretty(), "podman run --privileged --pid=host --user=root:root -v /var/lib/containers:/var/lib/containers -v 'this has spaces' label=type:unconfined_t --env=RUST_LOG=trace quay.io/ckyrouac/bootc-dev bootc install to-existing-root");
+        similar_asserts::assert_eq!(
+            cmd.to_string_pretty(),
+            "podman run --privileged --pid=host --user=root:root -v /var/lib/containers:/var/lib/containers -v 'this has spaces' label=type:unconfined_t --env=RUST_LOG=trace quay.io/ckyrouac/bootc-dev bootc install to-existing-root"
+        );
     }
 }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -4,7 +4,7 @@
 name = "xtask"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [[bin]]

--- a/crates/xtask/src/buildsys.rs
+++ b/crates/xtask/src/buildsys.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 const DOCKERFILE_NETWORK_CUTOFF: &str = "external dependency cutoff point";
 

--- a/crates/xtask/src/man.rs
+++ b/crates/xtask/src/man.rs
@@ -8,7 +8,7 @@ use camino::Utf8Path;
 use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 use std::{fs, io::Write};
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 /// Represents a CLI option extracted from the JSON dump
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/xtask/src/tmt.rs
+++ b/crates/xtask/src/tmt.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use rand::Rng;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 // Generation markers for integration.fmf
 const PLAN_MARKER_BEGIN: &str = "# BEGIN GENERATED PLANS\n";

--- a/crates/xtask/src/xtask.rs
+++ b/crates/xtask/src/xtask.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Args, Parser, Subcommand};
 use fn_error_context::context;
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 mod buildsys;
 mod man;


### PR DESCRIPTION
## Summary

This PR updates the entire workspace to Rust edition 2024, resolving #1414.

## Changes
- Updated `edition = "2024"` in all crate `Cargo.toml` files
- Fixed code compatibility issues for Rust 2024:
  - Added `#[allow(unsafe_code)]` to `global_init()` function of `crates/lib/src/cli.rs` for `std::env::set_var` 
- Bumped MSRV to 1.85.0 in `bootc-lib` and `system-reinstall-bootc`
- `cargo fmt --all`
- many variables has been renamed from `gen` to `generator` because `gen` is now a reserved keyword

## MSRV Considerations

The MSRV is set to 1.85.0 (minimum for edition 2024), but some dependencies 
require higher versions:
- `composefs` (git dependency) requires 1.88.0
- `openssh-keys@0.6.5` requires 1.90.0

**RHEL 9 Availability**: According to the public UBI9 repository, RHEL 9 
currently ships `rust-toolset-1.88.0-1.el9`

This means:
- `bootc-lib` cannot build with Rust < 1.88.0
- `system-reinstall-bootc` cannot build with Rust < 1.90.0

**Question for maintainers:** Should the `rust-version` fields be updated to 
reflect actual dependency requirements (1.88.0 and 1.90.0 respectively)? 

## Notes on `unsafe` usage

The `global_init()` function now uses `#[allow(unsafe_code)]` because 
`std::env::set_var` is marked unsafe in Rust 2024 edition. This is safe 
because:

1. The function is explicitly documented to be called early in `main()`
2. It's called before any threads are spawned (see `crates/cli/src/main.rs`)
3. This workaround is needed for bootc-image-builder compatibility

I'm seeking maintainer approval for this localized unsafe exception, as the 
project policy is `-D unsafe-code` workspace-wide.

Closes #1414