### PR TITLE
composefs: Fix is_image_pulled check

### DIFF
--- a/crates/lib/src/bootc_composefs/update.rs
+++ b/crates/lib/src/bootc_composefs/update.rs
@@ -53,8 +53,11 @@ pub(crate) async fn is_image_pulled(
 
     let img_digest = img_config_manifest.manifest.config().digest().digest();
 
+    // TODO: export config_identifier function from composefs-oci/src/lib.rs and use it here
+    let img_id = format!("oci-config-sha256:{img_digest}");
+
     // NB: add deep checking?
-    let container_pulled = repo.has_stream(img_digest).context("Checking stream")?;
+    let container_pulled = repo.has_stream(&img_id).context("Checking stream")?;
 
     Ok((container_pulled, img_config_manifest))
 }


### PR DESCRIPTION
Since 49d753f, upstream composefs-oci now writes manifest stream identifier as oci-config-sha256:<sha256 checksum>. ([ref](https://github.com/containers/composefs-rs/blob/4397870638b05e4c3374c6ae16e25ff3b9c7efbf/crates/composefs-oci/src/lib.rs#L36))

This was not updated in commit mentioned above, causing bootc always attempting to upgrade when `bootc upgrade` is ran, which will fail later at state writing stage due to already existing state directory. 