### PR TITLE
Drop fedora-44 from gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,24 @@ jobs:
       matrix:
         test_os: [fedora-42, fedora-43, fedora-44, centos-9, centos-10]
         variant: [ostree, composefs-sealeduki-sdboot]
+        gating: [true]
         exclude:
           # centos-9 UKI is experimental/broken (https://github.com/bootc-dev/bootc/issues/1812)
           - test_os: centos-9
             variant: composefs-sealeduki-sdboot
-
+          - test_os: fedora-44
+            gating: true
+        include:
+          # fedora-44 non-gating due to grub2 regression
+          # https://bugzilla.redhat.com/show_bug.cgi?id=2429501
+          - test_os: fedora-44
+            gating: false
+            variant: ostree
+          - test_os: fedora-44
+            gating: false
+            variant: composefs-sealeduki-sdboot
+    # Non-gating jobs are allowed to fail without blocking the PR
+    continue-on-error: ${{ !matrix.gating }}
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Add a `gating` matrix property to test-integration jobs. Jobs with `gating: false` use `continue-on-error: true`, allowing them to fail without blocking PR merges.

Mark fedora-44 as non-gating due to a grub2 regression in the base image (https://bugzilla.redhat.com/show_bug.cgi?id=2429501).

Assisted-by: OpenCode (Claude Sonnet 4)