### PR TITLE
install: support configuring sysroot.bls-append-except-default

### DIFF
--- a/crates/ostree-ext/src/lib.rs
+++ b/crates/ostree-ext/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ostree_prepareroot;
 pub mod refescape;
 #[doc(hidden)]
 pub mod repair;
+pub mod repo_options;
 pub mod sysroot;
 pub mod tar;
 pub mod tokio_util;

--- a/crates/ostree-ext/src/repo_options.rs
+++ b/crates/ostree-ext/src/repo_options.rs
@@ -1,0 +1,30 @@
+//! Configuration options for an ostree repository
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration options for an ostree repository.
+///
+/// This struct represents configurable options for an ostree repository
+/// that can be set via the `ostree config set` command.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RepoOptions {
+    /// Boot Loader Spec entries that should append arguments only for non-default entries.
+    ///
+    /// Corresponds to the `sysroot.bls-append-except-default` ostree config key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bls_append_except_default: Option<String>,
+}
+
+impl RepoOptions {
+    /// Returns an iterator of (key, value) tuples for ostree repo configuration.
+    ///
+    /// Each tuple represents an ostree config key and its value, suitable for
+    /// passing to `ostree config set`.
+    pub fn to_config_tuples(&self) -> impl Iterator<Item = (&'static str, &str)> {
+        self.bls_append_except_default
+            .as_ref()
+            .map(|v| ("sysroot.bls-append-except-default", v.as_str()))
+            .into_iter()
+    }
+}

--- a/docs/src/man/bootc-install-config.5.md
+++ b/docs/src/man/bootc-install-config.5.md
@@ -16,7 +16,7 @@ that can be overridden in a derived container image.
 
 This is the only defined toplevel table.
 
-The `install` section supports two subfields:
+The `install` section supports these subfields:
 
 - `block`: An array of supported `to-disk` backends enabled by this base container image;
    if not specified, this will just be `direct`.  The only other supported value is `tpm2-luks`.
@@ -24,6 +24,7 @@ The `install` section supports two subfields:
 - `filesystem`: See below.
 - `kargs`: An array of strings; this will be appended to the set of kernel arguments.
 - `match_architectures`: An array of strings; this filters the install config.
+- `ostree`: See below.
 
 # filesystem
 
@@ -37,6 +38,14 @@ There is one valid field:
 
 `type`: This can be any basic Linux filesystem with a `mkfs.$fstype`.  For example, `ext4`, `xfs`, etc.
 
+# ostree
+
+Configuration options for the ostree repository. There is one valid field:
+
+- `bls-append-except-default`: A string of kernel arguments that will be appended to
+  Boot Loader Spec entries, except for the default entry. This is useful for configuring
+  arguments that should only apply to non-default deployments.
+
 # Examples
 
 ```toml
@@ -44,6 +53,8 @@ There is one valid field:
 type = "xfs"
 [install]
 kargs = ["nosmt", "console=tty0"]
+[install.ostree]
+bls-append-except-default = 'grub_users=""'
 ```
 
 # SEE ALSO


### PR DESCRIPTION
Add a new [install.ostree] configuration section to allow setting the ostree sysroot.bls-append-except-default option during installation.

Closes: https://github.com/bootc-dev/bootc/issues/1710

Signed-off-by: Joel Capitao <jcapitao@redhat.com>
Co-authored-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>
Assisted-by: Claude (Sonnet 4)