### PR TITLE
ostree-ext/tar: Unset G_MESSAGES_DEBUG before spawning ostree commit

### DIFF
--- a/crates/ostree-ext/src/tar/write.rs
+++ b/crates/ostree-ext/src/tar/write.rs
@@ -400,6 +400,12 @@ pub async fn write_tar(
         None
     };
     let mut c = std::process::Command::new("ostree");
+    // Unset G_MESSAGES_DEBUG to prevent GLib debug messages from corrupting stdout.
+    // When G_MESSAGES_DEBUG is set (e.g., "all"), GLib and OSTree emit debug messages
+    // to stdout instead of stderr, which corrupts the commit hash we parse from
+    // the subprocess output. This causes derived layer content to be silently lost
+    // during container imports.
+    c.env_remove("G_MESSAGES_DEBUG");
     let repofd = repo.dfd_as_file()?;
     let repofd: Arc<io_lifetimes::OwnedFd> = Arc::new(repofd.into());
     {


### PR DESCRIPTION
When G_MESSAGES_DEBUG is set (e.g., 'all'), GLib and OSTree emit debug messages to stdout instead of stderr. This corrupts the commit hash that we parse from the ostree commit subprocess output, causing derived layer content to be silently lost during container imports.

The issue manifests as packages installed via 'dnf install' in a Containerfile not appearing in the deployed system's rpmdb after a rebase/upgrade operation.

Fixes: https://issues.redhat.com/browse/OCPBUGS-64692

Assisted-by: OpenCode (Claude Opus 4.5)