### PR TITLE
Fully disable fedora 44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,26 +152,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_os: [fedora-42, fedora-43, fedora-44, centos-9, centos-10]
+        # No fedora-44 due to https://bugzilla.redhat.com/show_bug.cgi?id=2429501
+        test_os: [fedora-42, fedora-43, centos-9, centos-10]
         variant: [ostree, composefs-sealeduki-sdboot]
-        gating: [true]
         exclude:
           # centos-9 UKI is experimental/broken (https://github.com/bootc-dev/bootc/issues/1812)
           - test_os: centos-9
             variant: composefs-sealeduki-sdboot
-          - test_os: fedora-44
-            gating: true
-        include:
-          # fedora-44 non-gating due to grub2 regression
-          # https://bugzilla.redhat.com/show_bug.cgi?id=2429501
-          - test_os: fedora-44
-            gating: false
-            variant: ostree
-          - test_os: fedora-44
-            gating: false
-            variant: composefs-sealeduki-sdboot
-    # Non-gating jobs are allowed to fail without blocking the PR
-    continue-on-error: ${{ !matrix.gating }}
+
     runs-on: ubuntu-24.04
 
     steps:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -74,8 +74,9 @@ jobs:
       - fedora-42-aarch64
       - fedora-43-x86_64
       - fedora-43-aarch64
-      - fedora-rawhide-x86_64
-      - fedora-rawhide-aarch64
+      # https://bugzilla.redhat.com/show_bug.cgi?id=2429501
+      # - fedora-rawhide-x86_64
+      # - fedora-rawhide-aarch64
     tmt_plan: /tmt/plans/integration
     tf_extra_params:
       environments:


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/show_bug.cgi?id=2429501

This reverts the prior change to make the test non gating because the problem is we'd consistently fail to do a bootc install *for each test* which dramatically slowed down that job.

We could fix that but it's easier to just disable the job.