### PR TITLE
etc-merge: Create directory in new_etc if deleted

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1823,13 +1823,15 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 let (p, c, n) =
                     etc_merge::traverse_etc(&pristine_etc, &current_etc, Some(&new_etc))?;
 
-                let diff = compute_diff(&p, &c)?;
+                let n = n
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("Failed to get new directory tree"))?;
+
+                let diff = compute_diff(&p, &c, &n)?;
                 print_diff(&diff, &mut std::io::stdout());
 
                 if merge {
-                    let n =
-                        n.ok_or_else(|| anyhow::anyhow!("Failed to get dirtree for new etc"))?;
-                    etc_merge::merge(&current_etc, &c, &new_etc, &n, diff)?;
+                    etc_merge::merge(&current_etc, &c, &new_etc, &n, &diff)?;
                 }
 
                 Ok(())


### PR DESCRIPTION
If a directory is modified/added in the current etc, but deleted in the new etc, we'd want it in the new etc. This case prior to this commit resulted in a panic as we were not taking it into account

Fixes: https://github.com/bootc-dev/bootc/issues/1924