### PR TITLE
ci: Update schedule release cadence to account for the new year

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -47,7 +47,7 @@ jobs:
             exit 0
           fi
 
-          START_DATE="2025-08-04" # start of a 3 week sprint
+          START_DATE="2026-01-05" # start of a 3 week sprint
           START_TIMESTAMP=$(date -d "$START_DATE" +%s)
           CURRENT_TIMESTAMP=$(date +%s)
           # Add 12 hour buffer (43200 seconds) to account for scheduling delays


### PR DESCRIPTION
The new 3 week cadence starts on 2026-01-26.