### PR TITLE
Fix destructive-cleanup failure when no old packages exist

### DIFF
--- a/contrib/scripts/fedora-bootc-destructive-cleanup
+++ b/contrib/scripts/fedora-bootc-destructive-cleanup
@@ -5,7 +5,7 @@ set -xeuo pipefail
 
 # Remove all RPMs installed in the physical root (i.e. the previous OS)
 mount -o remount,rw /sysroot
-rpm -qa --root=/sysroot --dbpath=/usr/lib/sysimage/rpm | xargs rpm -e --root=/sysroot --dbpath=/usr/lib/sysimage/rpm
+rpm -qa --root=/sysroot --dbpath=/usr/lib/sysimage/rpm | xargs -r rpm -e --root=/sysroot --dbpath=/usr/lib/sysimage/rpm
 
 # Remove all container images (including the one that was used to install)
 # Note that this does not remove stopped containers, and so some storage


### PR DESCRIPTION
When rpm -qa returns no packages, xargs would still invoke rpm -e with no arguments, causing failure with "no packages given for erase" (exit code 123).

Add -r flag to xargs to skip execution when input is empty.

Resolves https://github.com/bootc-dev/bootc/issues/1935