### PR TITLE
test: Add test required packages in Packit provision

### DIFF
--- a/hack/packages.txt
+++ b/hack/packages.txt
@@ -3,3 +3,8 @@ rsync
 cloud-init
 /usr/bin/flock
 /usr/bin/awk
+# Required by install-to-filesystem-var-mount test
+parted
+lvm2
+dosfstools
+e2fsprogs


### PR DESCRIPTION
`install-to-filesystem-var-mount` test requires packages which should be built into image for Packit provision (system-reinstall-bootc on package mode testing farm runner)