### PR TITLE
docs: Move composefs tracking from issue #1190 to docs

### DIFF
--- a/docs/src/experimental-composefs.md
+++ b/docs/src/experimental-composefs.md
@@ -82,8 +82,6 @@ EORUN
 # Final image: copy the sealed UKI into place
 FROM rootfs
 COPY --from=sealed-uki /out/*.efi /boot/EFI/Linux/
-# Remove raw kernel/initramfs (now embedded in UKI)
-RUN rm -f /usr/lib/modules/*/vmlinuz /usr/lib/modules/*/initramfs.img
 ```
 
 This pattern works because:


### PR DESCRIPTION
The composefs backend implementation has largely landed. Consolidate tracking of known issues into the docs, categorized by severity:

- Deployment blockers: GC, SELinux enforcing=0, OCI registry install
- Important: Sealed image build UX, kargs.d support
- Long-term: Unified storage, UKI/systemd-boot improvements

Closes: #1190

Assisted-by: OpenCode (Opus 4.5)