### PR TITLE
test: Fix bib test failure and add required package in bib test

### DIFF
--- a/hack/packages.txt
+++ b/hack/packages.txt
@@ -8,3 +8,5 @@ parted
 lvm2
 dosfstools
 e2fsprogs
+# Required by  bib-build test
+qemu-img

--- a/tmt/tests/booted/test-bib-build.nu
+++ b/tmt/tests/booted/test-bib-build.nu
@@ -95,7 +95,7 @@ DISKEOF
     let bib_image = $BIB_IMAGE
     # Note: we disable SELinux labeling since we're running in a test VM
     # and use unconfined_t to avoid permission issues
-    podman run --rm --privileged -v /var/lib/containers/storage:/var/lib/containers/storage --security-opt label=type:unconfined_t -v ./output:/output $bib_image --type qcow2 --local localhost/bootc-bib-test
+    podman run --rm --privileged -v /var/lib/containers/storage:/var/lib/containers/storage --security-opt label=type:unconfined_t -v ./output:/output $bib_image --type qcow2 --rootfs xfs localhost/bootc-bib-test
 
     # Verify output was created
     print "=== Verifying output ==="


### PR DESCRIPTION
Fix bib test failure with `error: cannot build manifest: no default fs set: mount "/boot" requires a filesystem but none set`.
Add bib test required package `qemu-img` into `packages.txt`.