### PR TITLE
Support stateroot and mount specs in install config file

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -2239,7 +2239,12 @@ pub(crate) async fn install_to_filesystem(
     // We support overriding the mount specification for root (i.e. LABEL vs UUID versus
     // raw paths).
     // We also support an empty specification as a signal to omit any mountspec kargs.
-    let root_info = if let Some(s) = fsopts.root_mount_spec {
+    // CLI takes precedence over config file.
+    let config_root_mount_spec = state
+        .install_config
+        .as_ref()
+        .and_then(|c| c.root_mount_spec.as_ref());
+    let root_info = if let Some(s) = fsopts.root_mount_spec.as_ref().or(config_root_mount_spec) {
         RootMountInfo {
             mount_spec: s.to_string(),
             kargs: Vec::new(),
@@ -2320,7 +2325,12 @@ pub(crate) async fn install_to_filesystem(
     let device_info = bootc_blockdev::partitions_of(Utf8Path::new(&backing_device))?;
 
     let rootarg = format!("root={}", root_info.mount_spec);
-    let mut boot = if let Some(spec) = fsopts.boot_mount_spec {
+    // CLI takes precedence over config file.
+    let config_boot_mount_spec = state
+        .install_config
+        .as_ref()
+        .and_then(|c| c.boot_mount_spec.as_ref());
+    let mut boot = if let Some(spec) = fsopts.boot_mount_spec.as_ref().or(config_boot_mount_spec) {
         // An empty boot mount spec signals to omit the mountspec kargs
         // See https://github.com/bootc-dev/bootc/issues/1441
         if spec.is_empty() {

--- a/docs/src/man/bootc-install-config.5.md
+++ b/docs/src/man/bootc-install-config.5.md
@@ -26,6 +26,13 @@ The `install` section supports these subfields:
 - `match_architectures`: An array of strings; this filters the install config.
 - `ostree`: See below.
 - `stateroot`: The stateroot name to use. Defaults to `default`.
+- `root-mount-spec`: A string specifying the root filesystem mount specification.
+   For example, `UUID=2e9f4241-229b-4202-8429-62d2302382e1` or `LABEL=rootfs`.
+   If not provided, the UUID of the target filesystem will be used.
+   An empty string signals to omit boot mount kargs entirely.
+- `boot-mount-spec`: A string specifying the /boot filesystem mount specification.
+   If not provided and /boot is a separate mount, its UUID will be used.
+   An empty string signals to omit boot mount kargs entirely.
 
 # filesystem
 
@@ -52,9 +59,12 @@ Configuration options for the ostree repository. There is one valid field:
 ```toml
 [install.filesystem.root]
 type = "xfs"
+
 [install]
 kargs = ["nosmt", "console=tty0"]
 stateroot = "myos"
+root-mount-spec = "LABEL=rootfs"
+boot-mount-spec = "UUID=abcd-1234"
 
 [install.ostree]
 bls-append-except-default = 'grub_users=""'


### PR DESCRIPTION
    install: Allow setting ostree stateroot in install config
    
    Support for configuring the stateroot name through the install
    configuration file under `[install.ostree]`.
    The CLI flag will override config file values, as for other options.
    
    Partial fix for https://github.com/bootc-dev/bootc/issues/1939
    
    Assisted-by: Opencode (Claude Opus 4.5)
    Signed-off-by: jbtrystram <jbtrystram@redhat.com>

   
   
   ----
   
    install: Allow root and boot mount-specs in config
    
    Allow configuring the root and boot filesystem mount
    specs via the install configuration file under [install].
    
    As for other options, CLI arguments take precedence.
    
    For the to-existing-root flow, mount specs from config are ignored.
    Example configuration:
    ```
    [install]
    root-mount-spec = "LABEL=rootfs"
    boot-mount-spec = "UUID=abcd-1234"
    ```
    
    Fixes https://github.com/bootc-dev/bootc/issues/1939
    
    Assisted-by: Opencode (Claude Opus 4.5)
    Signed-off-by: jbtrystram <jbtrystram@redhat.com>

