### PR TITLE
ci: Build test binaries before sudo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,11 @@ jobs:
           just copy-to-rootful localhost/bootc-install
           # Copy bound images (LBI) to root's storage for tests that need them
           just copy-lbi-to-rootful
-          sudo podman build -t localhost/bootc-fsverity -f ci/Containerfile.install-fsverity
 
-          # TODO move into a container, and then have this tool run other containers
+          # Build test binaries before any sudo commands to avoid cargo permission issues
           cargo build --release -p tests-integration
+
+          sudo podman build -t localhost/bootc-fsverity -f ci/Containerfile.install-fsverity
 
           df -h /
           sudo install -m 0755 target/release/tests-integration /usr/bin/bootc-integration-tests


### PR DESCRIPTION
CI failed on `Test Install` test: https://github.com/bootc-dev/bootc/actions/runs/21350622481/job/61598071031?pr=1954

Solution: 
- Move `cargo build --release -p tests-integration` to run before `sudo podman build` to avoid cargo registry permission issues.
- The tests-integration binary doesn't depend on the fsverity image, so this reordering has no functional impact on the test flow.