### PR TITLE
feat: Add `bootc container ukify` command

### DIFF
--- a/contrib/packaging/seal-uki
+++ b/contrib/packaging/seal-uki
@@ -12,15 +12,7 @@ shift
 secrets=$1
 shift
 
-# Compute the composefs digest from the target rootfs
-composefs_digest=$(bootc container compute-composefs-digest "${target}")
-
-# Build the kernel command line
-# enforcing=0: https://github.com/bootc-dev/bootc/issues/1826
-# TODO: pick up kargs from /usr/lib/bootc/kargs.d
-cmdline="composefs=${composefs_digest} console=ttyS0,115200n8 console=hvc0 enforcing=0 rw"
-
-# Find the kernel version
+# Find the kernel version (needed for output filename)
 kver=$(bootc container inspect --rootfs "${target}" --json | jq -r '.kernel.version')
 if [ -z "$kver" ] || [ "$kver" = "null" ]; then
   echo "Error: No kernel found" >&2
@@ -29,12 +21,14 @@ fi
 
 mkdir -p "${output}"
 
-ukify build \
-  --linux "${target}/usr/lib/modules/${kver}/vmlinuz" \
-  --initrd "${target}/usr/lib/modules/${kver}/initramfs.img" \
-  --uname="${kver}" \
-  --cmdline "${cmdline}" \
-  --os-release "@${target}/usr/lib/os-release" \
+# Build the UKI using bootc container ukify
+# This computes the composefs digest, reads kargs from kargs.d, and invokes ukify
+#
+# WORKAROUND: SELinux must be permissive for sealed UKI boot
+# See https://github.com/bootc-dev/bootc/issues/1826
+bootc container ukify --rootfs "${target}" \
+  --karg enforcing=0 \
+  -- \
   --signtool sbsign \
   --secureboot-private-key "${secrets}/secureboot_key" \
   --secureboot-certificate "${secrets}/secureboot_cert" \

--- a/contrib/packaging/usr-extras/lib/bootc/kargs.d/10-rootfs-rw.toml
+++ b/contrib/packaging/usr-extras/lib/bootc/kargs.d/10-rootfs-rw.toml
@@ -1,0 +1,2 @@
+# Mount the root filesystem read-write
+kargs = ["rw"]

--- a/contrib/packaging/usr-extras/lib/bootc/kargs.d/21-console-hvc0.toml
+++ b/contrib/packaging/usr-extras/lib/bootc/kargs.d/21-console-hvc0.toml
@@ -1,2 +1,3 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=2353887
-kargs = ["console=hvc0"]
+# console=ttyS0 for QEMU serial, console=hvc0 for virtio/Xen console
+kargs = ["console=ttyS0,115200n8", "console=hvc0"]

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1587,7 +1587,7 @@ async fn prepare_install(
 
     let composefs_required = if let Some(root) = target_rootfs.as_ref() {
         crate::kernel::find_kernel(root)?
-            .map(|k| k.unified)
+            .map(|k| k.kernel.unified)
             .unwrap_or(false)
     } else {
         false

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -93,6 +93,7 @@ pub mod spec;
 mod status;
 mod store;
 mod task;
+mod ukify;
 mod utils;
 
 #[cfg(feature = "docgen")]

--- a/crates/lib/src/status.rs
+++ b/crates/lib/src/status.rs
@@ -863,7 +863,7 @@ pub(crate) fn container_inspect(
     )?;
     let kargs = crate::bootc_kargs::get_kargs_in_root(&root, std::env::consts::ARCH)?;
     let kargs: Vec<String> = kargs.iter_str().map(|s| s.to_owned()).collect();
-    let kernel = crate::kernel::find_kernel(&root)?;
+    let kernel = crate::kernel::find_kernel(&root)?.map(Into::into);
     let inspect = crate::spec::ContainerInspect { kargs, kernel };
 
     // Determine output format: explicit --format wins, then --json, then default to human-readable

--- a/crates/lib/src/ukify.rs
+++ b/crates/lib/src/ukify.rs
@@ -1,0 +1,166 @@
+//! Build Unified Kernel Images (UKI) using ukify.
+//!
+//! This module provides functionality to build UKIs by computing the necessary
+//! arguments from a container image and invoking the ukify tool.
+
+use std::ffi::OsString;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use bootc_kernel_cmdline::utf8::Cmdline;
+use bootc_utils::CommandRunExt;
+use camino::Utf8Path;
+use cap_std_ext::cap_std::fs::Dir;
+use fn_error_context::context;
+
+use crate::bootc_composefs::digest::compute_composefs_digest;
+use crate::composefs_consts::COMPOSEFS_CMDLINE;
+
+/// Build a UKI from the given rootfs.
+///
+/// This function:
+/// 1. Verifies that ukify is available
+/// 2. Finds the kernel in the rootfs
+/// 3. Computes the composefs digest
+/// 4. Reads kernel arguments from kargs.d
+/// 5. Appends any additional kargs provided via --karg
+/// 6. Invokes ukify with computed arguments plus any pass-through args
+#[context("Building UKI")]
+pub(crate) fn build_ukify(
+    rootfs: &Utf8Path,
+    extra_kargs: &[String],
+    args: &[OsString],
+) -> Result<()> {
+    // Warn if --karg is used (temporary workaround)
+    if !extra_kargs.is_empty() {
+        tracing::warn!(
+            "The --karg flag is temporary and will be removed as soon as possible \
+            (https://github.com/bootc-dev/bootc/issues/1826)"
+        );
+    }
+
+    // Verify ukify is available
+    if !crate::utils::have_executable("ukify")? {
+        anyhow::bail!(
+            "ukify executable not found in PATH. Please install systemd-ukify or equivalent."
+        );
+    }
+
+    // Open the rootfs directory
+    let root = Dir::open_ambient_dir(rootfs, cap_std_ext::cap_std::ambient_authority())
+        .with_context(|| format!("Opening rootfs {rootfs}"))?;
+
+    // Find the kernel
+    let kernel = crate::kernel::find_kernel(&root)?
+        .ok_or_else(|| anyhow::anyhow!("No kernel found in {rootfs}"))?;
+
+    // We can only build a UKI from a traditional kernel, not from an existing UKI
+    if kernel.kernel.unified {
+        anyhow::bail!(
+            "Cannot build UKI: rootfs already contains a UKI at boot/EFI/Linux/{}.efi",
+            kernel.kernel.version
+        );
+    }
+
+    // Get paths from the kernel info
+    let vmlinuz_path = kernel
+        .vmlinuz
+        .ok_or_else(|| anyhow::anyhow!("Traditional kernel should have vmlinuz path"))?;
+    let initramfs_path = kernel
+        .initramfs
+        .ok_or_else(|| anyhow::anyhow!("Traditional kernel should have initramfs path"))?;
+
+    // Verify kernel and initramfs exist
+    if !root
+        .try_exists(&vmlinuz_path)
+        .context("Checking for vmlinuz")?
+    {
+        anyhow::bail!("Kernel not found at {vmlinuz_path}");
+    }
+    if !root
+        .try_exists(&initramfs_path)
+        .context("Checking for initramfs")?
+    {
+        anyhow::bail!("Initramfs not found at {initramfs_path}");
+    }
+
+    // Compute the composefs digest
+    let composefs_digest = compute_composefs_digest(rootfs, None)?;
+
+    // Get kernel arguments from kargs.d
+    let mut cmdline = crate::bootc_kargs::get_kargs_in_root(&root, std::env::consts::ARCH)?;
+
+    // Add the composefs digest
+    let composefs_param = format!("{COMPOSEFS_CMDLINE}={composefs_digest}");
+    cmdline.extend(&Cmdline::from(composefs_param));
+
+    // Add any extra kargs provided via --karg
+    for karg in extra_kargs {
+        cmdline.extend(&Cmdline::from(karg));
+    }
+
+    let cmdline_str = cmdline.to_string();
+
+    // Build the ukify command with cwd set to rootfs so paths can be relative
+    let mut cmd = Command::new("ukify");
+    cmd.current_dir(rootfs);
+    cmd.arg("build")
+        .arg("--linux")
+        .arg(&vmlinuz_path)
+        .arg("--initrd")
+        .arg(&initramfs_path)
+        .arg("--uname")
+        .arg(&kernel.kernel.version)
+        .arg("--cmdline")
+        .arg(&cmdline_str)
+        .arg("--os-release")
+        .arg("@usr/lib/os-release");
+
+    // Add pass-through arguments
+    cmd.args(args);
+
+    tracing::debug!("Executing ukify: {:?}", cmd);
+
+    // Run ukify
+    cmd.run_inherited().context("Running ukify")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_build_ukify_no_kernel() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = Utf8Path::from_path(tempdir.path()).unwrap();
+
+        let result = build_ukify(path, &[], &[]);
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("No kernel found") || err.contains("ukify executable not found"),
+            "Unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_ukify_already_uki() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = Utf8Path::from_path(tempdir.path()).unwrap();
+
+        // Create a UKI structure
+        fs::create_dir_all(tempdir.path().join("boot/EFI/Linux")).unwrap();
+        fs::write(tempdir.path().join("boot/EFI/Linux/test.efi"), b"fake uki").unwrap();
+
+        let result = build_ukify(path, &[], &[]);
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(
+            err.contains("already contains a UKI") || err.contains("ukify executable not found"),
+            "Unexpected error message: {err}"
+        );
+    }
+}

--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -67,7 +67,6 @@ pub(crate) fn find_mount_option<'a>(
         .next()
 }
 
-#[allow(dead_code)]
 pub fn have_executable(name: &str) -> Result<bool> {
     let Some(path) = std::env::var_os("PATH") else {
         return Ok(false);

--- a/docs/src/man/bootc-container-ukify.8.md
+++ b/docs/src/man/bootc-container-ukify.8.md
@@ -1,0 +1,42 @@
+# NAME
+
+bootc-container-ukify - Build a Unified Kernel Image (UKI) using ukify
+
+# SYNOPSIS
+
+bootc container ukify [OPTIONS] [-- UKIFY_ARGS...]
+
+# DESCRIPTION
+
+Build a Unified Kernel Image (UKI) using ukify
+
+This command computes the necessary arguments from the container image
+(kernel, initrd, cmdline, os-release) and invokes ukify with them.
+Any additional arguments after `--` are passed through to ukify unchanged.
+
+# OPTIONS
+
+<!-- BEGIN GENERATED OPTIONS -->
+**ARGS**
+
+    Additional arguments to pass to ukify (after `--`)
+
+**--rootfs**=*ROOTFS*
+
+    Operate on the provided rootfs
+
+    Default: /
+
+<!-- END GENERATED OPTIONS -->
+
+# EXAMPLES
+
+    bootc container ukify --rootfs /target -- --output /output/uki.efi
+
+# SEE ALSO
+
+**bootc**(8), **ukify**(1)
+
+# VERSION
+
+<!-- VERSION PLACEHOLDER -->

--- a/docs/src/man/bootc-container.8.md
+++ b/docs/src/man/bootc-container.8.md
@@ -21,6 +21,7 @@ Operations which can be executed as part of a container build
 |---------|-------------|
 | **bootc container inspect** | Output information about the container image |
 | **bootc container lint** | Perform relatively inexpensive static analysis checks as part of a container build |
+| **bootc container ukify** | Build a Unified Kernel Image (UKI) using ukify |
 
 <!-- END GENERATED SUBCOMMANDS -->
 


### PR DESCRIPTION
Add a new subcommand that builds a Unified Kernel Image (UKI) by
computing the necessary arguments from a container image and invoking
ukify. This simplifies the sealed image build workflow by having bootc
internally compute:

- The composefs digest (via existing compute-composefs-digest logic)
- Kernel arguments from /usr/lib/bootc/kargs.d/*.toml files
- Paths to kernel, initrd, and os-release

Any additional arguments are passed through to ukify unchanged, allowing
full control over signing, output paths, and other ukify options.

The seal-uki script is updated to use this new command instead of
manually computing these values and invoking ukify directly.

Also adds kargs.d configuration files for the sealed UKI workflow:
- 10-rootfs-rw.toml: Mount root filesystem read-write
- 21-console-hvc0.toml: Console configuration for QEMU/virtio

Closes: #1955

Assisted-by: OpenCode (Opus 4.5)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
