### PR TITLE
[RFC] ostree-ext: import container layers directly from overlay filesystem

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1047,7 +1047,7 @@ async fn upgrade(
             crate::deploy::pull_unified(repo, imgref, None, opts.quiet, prog.clone(), storage)
                 .await?
         } else {
-            crate::deploy::pull(repo, imgref, None, opts.quiet, prog.clone()).await?
+            crate::deploy::pull(repo, imgref, None, opts.quiet, prog.clone(), Some(storage)).await?
         };
         let staged_digest = staged_image.map(|s| s.digest().expect("valid digest in status"));
         let fetched_digest = &fetched.manifest_digest;
@@ -1210,7 +1210,7 @@ async fn switch_ostree(
     let fetched = if use_unified {
         crate::deploy::pull_unified(repo, &target, None, opts.quiet, prog.clone(), storage).await?
     } else {
-        crate::deploy::pull(repo, &target, None, opts.quiet, prog.clone()).await?
+        crate::deploy::pull(repo, &target, None, opts.quiet, prog.clone(), Some(storage)).await?
     };
 
     if !opts.retain {
@@ -1347,7 +1347,15 @@ async fn edit_ostree(
         return crate::deploy::rollback(storage).await;
     }
 
-    let fetched = crate::deploy::pull(repo, new_spec.image, None, opts.quiet, prog.clone()).await?;
+    let fetched = crate::deploy::pull(
+        repo,
+        new_spec.image,
+        None,
+        opts.quiet,
+        prog.clone(),
+        Some(storage),
+    )
+    .await?;
 
     // TODO gc old layers here
 

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -969,7 +969,13 @@ async fn install_container(
         )
         .await?
     } else {
-        prepare_for_pull(repo, &spec_imgref, Some(&state.target_imgref)).await?
+        prepare_for_pull(
+            repo,
+            &spec_imgref,
+            Some(&state.target_imgref),
+            Some(storage),
+        )
+        .await?
     };
 
     let pulled_image = match prepared {
@@ -2513,6 +2519,7 @@ pub(crate) async fn install_reset(opts: InstallResetOpts) -> Result<()> {
             None,
             opts.quiet,
             prog.clone(),
+            Some(sysroot),
         )
         .await?;
         (fetched, new_spec)

--- a/crates/ostree-ext/src/filesystem/filter.rs
+++ b/crates/ostree-ext/src/filesystem/filter.rs
@@ -1,0 +1,313 @@
+use anyhow::{Context, Result, anyhow};
+use camino::Utf8Path;
+use ostree::gio;
+use ostree::glib;
+use ostree::prelude::*;
+use std::collections::BTreeMap;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::Path;
+
+use crate::tar::EXCLUDED_TOPLEVEL_PATHS;
+
+/// Configuration for filesystem filtering operations
+#[derive(Debug, Clone, Default)]
+pub struct FilesystemFilterConfig {
+    /// Allow content outside /usr (for transient rootfs with overlayfs)
+    pub allow_nonusr: bool,
+    /// Remap /var to /usr/share/factory/var
+    pub remap_factory_var: bool,
+    /// Base commit to get SELinux policy from (unused for layer import -
+    /// SELinux labeling happens during the merge step)
+    pub base: Option<String>,
+}
+
+impl FilesystemFilterConfig {
+    /// Create from WriteTarOptions
+    pub fn from_tar_options(opts: &crate::tar::WriteTarOptions) -> Self {
+        Self {
+            allow_nonusr: opts.allow_nonusr,
+            remap_factory_var: !opts.retain_var,
+            base: opts.base.clone(),
+        }
+    }
+}
+
+/// Describes how a toplevel directory should be handled during import
+enum ToplevelAction {
+    /// Import directly using write_dfd_to_mtree at the given destination path
+    Import { dest_path: &'static [&'static str] },
+    /// Skip this directory entirely
+    Skip,
+}
+
+/// Determine how to handle a toplevel directory entry
+fn classify_toplevel(name: &str, config: &FilesystemFilterConfig) -> ToplevelAction {
+    match name {
+        "usr" => ToplevelAction::Import {
+            dest_path: &["usr"],
+        },
+        "etc" => ToplevelAction::Import {
+            dest_path: &["usr", "etc"],
+        },
+        "var" if config.remap_factory_var => ToplevelAction::Import {
+            dest_path: &["usr", "share", "factory", "var"],
+        },
+        "var" => ToplevelAction::Import {
+            dest_path: &["var"],
+        },
+        name if EXCLUDED_TOPLEVEL_PATHS.contains(&name) => ToplevelAction::Skip,
+        _ if config.allow_nonusr => ToplevelAction::Import {
+            // For non-usr paths when allowed, we need to handle dynamically
+            // This case requires special handling since we can't return a static slice
+            dest_path: &[],
+        },
+        _ => ToplevelAction::Skip,
+    }
+}
+
+/// Check if a file is an overlay whiteout (character device with major/minor 0/0)
+fn is_overlay_whiteout(metadata: &std::fs::Metadata) -> bool {
+    let file_type = metadata.file_type();
+    if !file_type.is_char_device() {
+        return false;
+    }
+    // Check if rdev is 0 (major 0, minor 0)
+    metadata.rdev() == 0
+}
+
+/// Import a filesystem directory directly to OSTree with path transformations.
+///
+/// Uses `write_dfd_to_mtree` for each file individually, enabling reflinks while
+/// handling overlay whiteouts by converting them to OCI format.
+///
+/// Overlay whiteouts (char device 0/0) are converted to OCI-format whiteout files
+/// (`.wh.<filename>`) to match the behavior of the tar import path.
+///
+/// Note: SELinux labeling is NOT performed here. It happens during the merge step
+/// in the container import flow, where all layers are combined and labeled together
+/// with the correct destination paths.
+///
+/// Returns the commit checksum. The caller is responsible for setting the ref
+/// within a transaction.
+pub fn import_filesystem_to_ostree(
+    repo: &ostree::Repo,
+    src_path: &Utf8Path,
+    config: &FilesystemFilterConfig,
+) -> Result<crate::tar::WriteTarResult> {
+    let cancellable = gio::Cancellable::NONE;
+
+    // Create the root MutableTree
+    let root_mtree = ostree::MutableTree::new();
+    let mut filtered_stats = BTreeMap::new();
+
+    // Create a commit modifier - no SELinux here, it's applied during merge
+    let modifier = ostree::RepoCommitModifier::new(ostree::RepoCommitModifierFlags::CONSUME, None);
+
+    // Create default dirmeta for directories we create
+    let dirmeta_checksum = create_default_dirmeta(repo)?;
+
+    // Set the root tree's metadata checksum - required before write_mtree
+    root_mtree.set_metadata_checksum(&dirmeta_checksum);
+
+    // Read toplevel entries and process each according to its classification
+    let entries =
+        std::fs::read_dir(src_path).with_context(|| format!("Reading directory: {}", src_path))?;
+
+    for entry in entries {
+        let entry = entry.context("Reading directory entry")?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        let file_type = entry.file_type().context("Getting file type")?;
+
+        // Only process directories at toplevel
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let action = classify_toplevel(&name_str, config);
+
+        match action {
+            ToplevelAction::Import { dest_path } => {
+                // Handle the special case of dynamic non-usr paths
+                let dest_parts: Vec<&str> = if dest_path.is_empty() {
+                    vec![&name_str]
+                } else {
+                    dest_path.to_vec()
+                };
+
+                // Ensure the destination directory exists in the MutableTree
+                let dest_mtree = if dest_parts.len() == 1 {
+                    root_mtree
+                        .ensure_dir(dest_parts[0])
+                        .with_context(|| format!("Creating directory: {}", dest_parts[0]))?
+                } else {
+                    // For nested paths like usr/etc or usr/share/factory/var,
+                    // we need to ensure all parent directories exist
+                    root_mtree
+                        .ensure_parent_dirs(&dest_parts, &dirmeta_checksum)
+                        .with_context(|| {
+                            format!("Creating directory path: {}", dest_parts.join("/"))
+                        })?
+                };
+
+                // Set metadata checksum on the destination directory
+                dest_mtree.set_metadata_checksum(&dirmeta_checksum);
+
+                let src_dir_path = src_path.join(&*name_str);
+
+                // Import the directory recursively, handling whiteouts
+                import_directory_recursive(
+                    repo,
+                    src_dir_path.as_std_path(),
+                    &dest_mtree,
+                    &modifier,
+                    &dirmeta_checksum,
+                    cancellable,
+                )
+                .with_context(|| {
+                    format!(
+                        "Importing directory '{}' to '{}'",
+                        name_str,
+                        dest_parts.join("/")
+                    )
+                })?;
+            }
+            ToplevelAction::Skip => {
+                *filtered_stats.entry(name_str.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Convert MutableTree to a RepoFile
+    let root = repo
+        .write_mtree(&root_mtree, cancellable)
+        .context("Writing mtree")?;
+    let root = root
+        .downcast::<ostree::RepoFile>()
+        .map_err(|_| anyhow!("Expected RepoFile"))?;
+
+    // Create commit metadata
+    let metadata = glib::VariantDict::new(None);
+    metadata.insert(
+        "ostree.importer.version",
+        env!("CARGO_PKG_VERSION").to_variant(),
+    );
+    let metadata = metadata.to_variant();
+
+    // Write the commit
+    let commit = repo
+        .write_commit(None, None, None, Some(&metadata), &root, cancellable)
+        .context("Writing commit")?;
+
+    Ok(crate::tar::WriteTarResult {
+        commit: commit.to_string(),
+        filtered: filtered_stats,
+    })
+}
+
+/// Recursively import a directory, using write_dfd_to_mtree for each file
+/// and converting overlay whiteouts to OCI format.
+fn import_directory_recursive(
+    repo: &ostree::Repo,
+    src_dir: &Path,
+    mtree: &ostree::MutableTree,
+    modifier: &ostree::RepoCommitModifier,
+    dirmeta_checksum: &str,
+    cancellable: Option<&gio::Cancellable>,
+) -> Result<()> {
+    // Open the source directory for use with write_dfd_to_mtree
+    let src_fd = rustix::fs::openat(
+        rustix::fs::CWD,
+        src_dir,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::DIRECTORY,
+        rustix::fs::Mode::empty(),
+    )
+    .with_context(|| format!("Opening directory: {}", src_dir.display()))?;
+
+    let entries = std::fs::read_dir(src_dir)
+        .with_context(|| format!("Reading directory: {}", src_dir.display()))?;
+
+    for entry in entries {
+        let entry = entry.context("Reading directory entry")?;
+        let file_name = entry.file_name();
+        let file_name_str = file_name.to_string_lossy();
+        let file_path = entry.path();
+
+        let metadata = std::fs::symlink_metadata(&file_path)
+            .with_context(|| format!("Getting metadata for: {}", file_path.display()))?;
+        let file_type = metadata.file_type();
+
+        if file_type.is_dir() {
+            // Create subdirectory in mtree and recurse
+            let sub_mtree = mtree
+                .ensure_dir(&file_name_str)
+                .with_context(|| format!("Creating directory: {}", file_name_str))?;
+            sub_mtree.set_metadata_checksum(dirmeta_checksum);
+
+            import_directory_recursive(
+                repo,
+                &file_path,
+                &sub_mtree,
+                modifier,
+                dirmeta_checksum,
+                cancellable,
+            )?;
+        } else if file_type.is_file() || file_type.is_symlink() {
+            // Use write_dfd_to_mtree for the individual file - this enables reflinks
+            repo.write_dfd_to_mtree(
+                src_fd.as_raw_fd(),
+                &file_name_str,
+                mtree,
+                Some(modifier),
+                cancellable,
+            )
+            .with_context(|| format!("Importing file: {}", file_path.display()))?;
+        } else if is_overlay_whiteout(&metadata) {
+            // Convert overlay whiteout to OCI format (.wh.<filename>)
+            let whiteout_name = format!(".wh.{}", file_name_str);
+            let checksum = create_empty_file(repo)?;
+            mtree
+                .replace_file(&whiteout_name, &checksum)
+                .with_context(|| format!("Adding whiteout file: {}", whiteout_name))?;
+            tracing::debug!(
+                src = %file_path.display(),
+                dest = %whiteout_name,
+                "Converted overlay whiteout to OCI format"
+            );
+        } else {
+            // Skip other special files (sockets, fifos, block devices)
+            tracing::debug!(path = %file_path.display(), "Skipping special file");
+        }
+    }
+
+    Ok(())
+}
+
+/// Create default directory metadata and return its checksum
+fn create_default_dirmeta(repo: &ostree::Repo) -> Result<String> {
+    let cancellable = gio::Cancellable::NONE;
+
+    let finfo = gio::FileInfo::new();
+    finfo.set_file_type(gio::FileType::Directory);
+    finfo.set_attribute_uint32("unix::uid", 0);
+    finfo.set_attribute_uint32("unix::gid", 0);
+    finfo.set_attribute_uint32("unix::mode", libc::S_IFDIR | 0o755);
+
+    let dirmeta = ostree::create_directory_metadata(&finfo, None);
+    let checksum = repo
+        .write_metadata(ostree::ObjectType::DirMeta, None, &dirmeta, cancellable)?
+        .to_hex();
+
+    Ok(checksum)
+}
+
+/// Create an empty file and return its checksum (for whiteout files)
+fn create_empty_file(repo: &ostree::Repo) -> Result<String> {
+    let cancellable = gio::Cancellable::NONE;
+
+    let checksum =
+        repo.write_regfile_inline(None, 0, 0, libc::S_IFREG | 0o644, None, &[], cancellable)?;
+
+    Ok(checksum.to_string())
+}

--- a/crates/ostree-ext/src/filesystem/mod.rs
+++ b/crates/ostree-ext/src/filesystem/mod.rs
@@ -1,0 +1,42 @@
+//! Filesystem-based filtering and processing
+//!
+//! This module provides functionality to import filesystem directories directly
+//! to OSTree, applying path transformations without creating temporary files
+//! on disk.
+
+mod filter;
+
+pub use filter::{FilesystemFilterConfig, import_filesystem_to_ostree};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_from_tar_options() {
+        let tar_opts = crate::tar::WriteTarOptions {
+            base: None,
+            selinux: false,
+            allow_nonusr: true,
+            retain_var: false,
+        };
+
+        let fs_config = FilesystemFilterConfig::from_tar_options(&tar_opts);
+        assert!(fs_config.allow_nonusr);
+        assert!(fs_config.remap_factory_var); // !retain_var
+    }
+
+    #[test]
+    fn test_config_from_tar_options_retain_var() {
+        let tar_opts = crate::tar::WriteTarOptions {
+            base: None,
+            selinux: false,
+            allow_nonusr: false,
+            retain_var: true,
+        };
+
+        let fs_config = FilesystemFilterConfig::from_tar_options(&tar_opts);
+        assert!(!fs_config.allow_nonusr);
+        assert!(!fs_config.remap_factory_var); // !retain_var
+    }
+}

--- a/crates/ostree-ext/src/lib.rs
+++ b/crates/ostree-ext/src/lib.rs
@@ -39,6 +39,7 @@ pub mod cli;
 pub mod container;
 pub mod container_utils;
 pub mod diff;
+pub mod filesystem;
 pub(crate) mod generic_decompress;
 pub mod ima;
 pub mod keyfileext;

--- a/crates/ostree-ext/src/tar/write.rs
+++ b/crates/ostree-ext/src/tar/write.rs
@@ -29,9 +29,9 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tracing::instrument;
 
-// Exclude things in https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
-// from being placed in the rootfs.
-const EXCLUDED_TOPLEVEL_PATHS: &[&str] = &["run", "tmp", "proc", "sys", "dev"];
+/// Exclude things in https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
+/// from being placed in the rootfs.
+pub(crate) const EXCLUDED_TOPLEVEL_PATHS: &[&str] = &["run", "tmp", "proc", "sys", "dev"];
 
 /// Copy a tar entry to a new tar archive, optionally using a different filesystem path.
 #[context("Copying entry")]


### PR DESCRIPTION
When pulling container images from local containers-storage, detect overlay filesystem layers and import them directly to OSTree instead of processing tar streams. This allows to use reflinks on file systems that support them.

Assisted-by: Claude Opus 4.5

This is just a PoC at the moment, I've not fully reviewed the generated code yet.

@cgwalters This takes a different approach that we discussed, but I believe it is easier to maintain in the containers library, as it is much easier to add a new API to the image/storage library to expose low level objects (i.e. layer diff when available, file objects by their checksum...) that will replace the manual access to the overlay diff that is implemented now.

Another benefit, IMO, is that it moves us away from tarballs which ultimately I'd like to see it happening in the containers library as well.

I've manually tested the change and that reflinks are created to the files in the containers storage.