### PR TITLE
Update to latest composefs-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=4a060161e0122bd2727e639437c61e05ecc7cab3#4a060161e0122bd2727e639437c61e05ecc7cab3"
+source = "git+https://github.com/containers/composefs-rs?rev=ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d#ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d"
 dependencies = [
  "anyhow",
  "hex",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "composefs-boot"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=4a060161e0122bd2727e639437c61e05ecc7cab3#4a060161e0122bd2727e639437c61e05ecc7cab3"
+source = "git+https://github.com/containers/composefs-rs?rev=ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d#ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d"
 dependencies = [
  "anyhow",
  "composefs",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "composefs-oci"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=4a060161e0122bd2727e639437c61e05ecc7cab3#4a060161e0122bd2727e639437c61e05ecc7cab3"
+source = "git+https://github.com/containers/composefs-rs?rev=ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d#ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ clap_mangen = { version = "0.2.20" }
 #   composefs-boot = { path = "/home/user/src/composefs-rs/crates/composefs-boot" }
 #   composefs-oci = { path = "/home/user/src/composefs-rs/crates/composefs-oci" }
 # The Justfile will auto-detect these and bind-mount them into container builds.
-composefs = { git = "https://github.com/containers/composefs-rs", rev = "4a060161e0122bd2727e639437c61e05ecc7cab3", package = "composefs", features = ["rhel9"] }
-composefs-boot = { git = "https://github.com/containers/composefs-rs", rev = "4a060161e0122bd2727e639437c61e05ecc7cab3", package = "composefs-boot" }
-composefs-oci = { git = "https://github.com/containers/composefs-rs", rev = "4a060161e0122bd2727e639437c61e05ecc7cab3", package = "composefs-oci" }
+composefs = { git = "https://github.com/containers/composefs-rs", rev = "ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d", package = "composefs", features = ["rhel9"] }
+composefs-boot = { git = "https://github.com/containers/composefs-rs", rev = "ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d", package = "composefs-boot" }
+composefs-oci = { git = "https://github.com/containers/composefs-rs", rev = "ce3cd9bf7aa0ad2ee8d3814101aa9cd50fd3598d", package = "composefs-oci" }
 fn-error-context = "0.2.1"
 hex = "0.4.3"
 indicatif = "0.18.0"

--- a/crates/lib/src/cfsctl.rs
+++ b/crates/lib/src/cfsctl.rs
@@ -383,7 +383,7 @@ where
             }
         }
         Command::GC => {
-            repo.gc()?;
+            repo.gc(&[])?;
         }
     }
     Ok(())


### PR DESCRIPTION
To unblock reverse dependency testing.

(We still have the forked cfsctl, that's the only thing)