### PR TITLE
bootc-lib: fix ARM architecture support

### DIFF
--- a/crates/lib/src/discoverable_partition_specification.rs
+++ b/crates/lib/src/discoverable_partition_specification.rs
@@ -511,6 +511,8 @@ pub const fn this_arch_root() -> &'static str {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "x86_64")] {
             ROOT_X86_64
+        } else if #[cfg(target_arch = "arm")] {
+            ROOT_ARM
         } else if #[cfg(target_arch = "aarch64")] {
             ROOT_ARM64
         } else if #[cfg(target_arch = "s390x")] {


### PR DESCRIPTION
Currently build fails for armv7, this fixes the issue:

```
1094.0    Compiling bootc-lib v1.12.1 (/bootc/crates/lib)
1097.2 error: Unsupported architecture
1097.2    --> crates/lib/src/discoverable_partition_specification.rs:523:13
1097.2     |
1097.2 523 |             compile_error!("Unsupported architecture")
1097.2     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1097.2
1157.8 error: could not compile `bootc-lib` (lib) due to 1 previous error
1157.8 error: Generating manpages: Syncing man pages: Extracting CLI: Running CLI JSON dump command: command exited with non-zero code `cargo run --features=docgen -- internals dump-cli-json`: 101
1157.8 make: *** [Makefile:44: manpages] Error 1
1157.8 make: Leaving directory '/bootc'
```