### PR TITLE
bootupd: Fix /sys read-only mount issue

### DIFF
--- a/crates/utils/src/bwrap.rs
+++ b/crates/utils/src/bwrap.rs
@@ -80,7 +80,7 @@ impl<'a> BwrapCmd<'a> {
         // See https://systemd.io/API_FILE_SYSTEMS/
         cmd.args(["--proc", "/proc"]);
         cmd.args(["--dev", "/dev"]);
-        cmd.args(["--ro-bind", "/sys", "/sys"]);
+        cmd.args(["--bind", "/sys", "/sys"]);
 
         // Add bind mounts
         for (source, target) in &self.bind_mounts {


### PR DESCRIPTION
Bootc daily CI test failed on bootc install to-existing-root test on RHEL 9.x and 10.x with the following error. The failure comes from bootc commit `0a757685ee631ca9d53df6941af4fb71e4ac1bf3` or `0a757685ee631ca9d53df6941af4fb71e4ac1bf3`, because commit `51dabaa5cb7b6313b8cd75a002862c64de3c7b85` passed.

efibootmgr needs write access to /sys/firmware/efi/efivars to modify EFI boot variables (like deleting boot entries with -B)
This PR is a simple fix, mount /sys as read-write.

```
Installing bootloader via bootupd
Executing: "efibootmgr" "-b" "0002" "-B"
Could not delete variable: Read-only file system
error: boot data installation failed: installing component EFI: Updating EFI firmware variables: Clearing EFI boot entries that match target Red Hat Enterprise Linux: Failed to run command: Command {
    program: "efibootmgr",
    args: [
        "efibootmgr",
        "-b",
        "0002",
        "-B",
    ],
    create_pidfd: false,
}
error: Installing to filesystem: Installing bootloader: Failed to run command: Command {
    program: "bwrap",
    args: [
        "bwrap",
        "--bind",
        "/target/ostree/deploy/default/deploy/96b094a8419f0fd81c0434730e7906d00a3571017a8755761aab66df4c7270ea.0",
        "/",
        "--proc",
        "/proc",
        "--dev",
        "/dev",
        "--ro-bind",
        "/sys",
        "/sys",
        "--bind",
        "/target/boot",
        "/boot",
        "--dev-bind",
        "/dev/nvme0n1",
        "/dev/nvme0n1",
        "--dev-bind",
        "/dev/nvme0n1p1",
        "/dev/nvme0n1p1",
        "--dev-bind",
        "/dev/nvme0n1p2",
        "/dev/nvme0n1p2",
        "--dev-bind",
        "/dev/nvme0n1p3",
        "/dev/nvme0n1p3",
        "--setenv",
        "PATH",
        "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
        "--",
        "bootupctl",
        "backend",
        "install",
        "--write-uuid",
        "--update-firmware",
        "--auto",
        "--device",
        "/dev/nvme0n1",
        "/",
    ],
    create_pidfd: false,
}
```