### PR TITLE
test: Fix btrfs FS on CS10 image issue

### DIFF
--- a/contrib/packaging/configure-rootfs
+++ b/contrib/packaging/configure-rootfs
@@ -26,7 +26,8 @@ else
   fs=
   case "${VARIANT}" in
     composefs*)
-      btrfs=$(grep -qEe '^CONFIG_BTRFS_FS' /usr/lib/modules/${kver}/config && echo btrfs || true)
+      # CONFIG_BTRFS_FS=m has been added into CS10 kernel config
+      btrfs=$(grep -qEe '^CONFIG_BTRFS_FS=y' /usr/lib/modules/${kver}/config && echo btrfs || true)
       fs=${btrfs:-ext4}
       ;;
     *)


### PR DESCRIPTION
Test `centos-10, composefs-sealeduki-sdboot` failed (https://github.com/bootc-dev/bootc/actions/runs/21662811846/job/62588162722?pr=1974).

MR https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-10/-/merge_requests/2009 already added "CONFIG_BTRFS_FS=m" into `config`.

Update grub to use `CONFIG_BTRFS_FS=y` for btrfs support.