### PR TITLE
upgrade: Add pre-flight disk space check

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -190,9 +190,7 @@ use self::baseline::InstallBlockDeviceOpts;
 use crate::bootc_composefs::{boot::setup_composefs_boot, repo::initialize_composefs_repository};
 use crate::boundimage::{BoundImage, ResolvedBoundImage};
 use crate::containerenv::ContainerExecutionInfo;
-use crate::deploy::{
-    MergeState, PreparedImportMeta, PreparedPullResult, prepare_for_pull, pull_from_prepared,
-};
+use crate::deploy::{MergeState, PreparedPullResult, prepare_for_pull, pull_from_prepared};
 use crate::install::config::Filesystem as FilesystemEnum;
 use crate::lsm;
 use crate::progress_jsonl::ProgressWriter;
@@ -1012,27 +1010,6 @@ async fn initialize_ostree_root(state: &State, root_setup: &RootSetup) -> Result
     Ok((storage, has_ostree))
 }
 
-fn check_disk_space(
-    repo_fd: impl AsFd,
-    image_meta: &PreparedImportMeta,
-    imgref: &ImageReference,
-) -> Result<()> {
-    let stat = rustix::fs::fstatvfs(repo_fd)?;
-    let bytes_avail: u64 = stat.f_bsize * stat.f_bavail;
-    tracing::trace!("bytes_avail: {bytes_avail}");
-
-    if image_meta.bytes_to_fetch > bytes_avail {
-        anyhow::bail!(
-            "Insufficient free space for {image} (available: {bytes_avail} required: {bytes_to_fetch})",
-            bytes_avail = ostree_ext::glib::format_size(bytes_avail),
-            bytes_to_fetch = ostree_ext::glib::format_size(image_meta.bytes_to_fetch),
-            image = imgref.image,
-        );
-    }
-
-    Ok(())
-}
-
 #[context("Creating ostree deployment")]
 async fn install_container(
     state: &State,
@@ -1100,7 +1077,7 @@ async fn install_container(
     let pulled_image = match prepared {
         PreparedPullResult::AlreadyPresent(existing) => existing,
         PreparedPullResult::Ready(image_meta) => {
-            check_disk_space(root_setup.physical_root.as_fd(), &image_meta, &spec_imgref)?;
+            crate::deploy::check_disk_space_ostree(repo, &image_meta, &spec_imgref)?;
             pull_from_prepared(&spec_imgref, false, ProgressWriter::default(), *image_meta).await?
         }
     };

--- a/tmt/tests/booted/test-upgrade-preflight-disk-check.nu
+++ b/tmt/tests/booted/test-upgrade-preflight-disk-check.nu
@@ -1,0 +1,66 @@
+# number: 35
+# tmt:
+#   summary: Verify pre-flight disk space check rejects images with inflated layer sizes
+#   duration: 10m
+#
+# This test does NOT require a reboot.
+# It constructs a minimal fake OCI image directory that claims to have an
+# astronomically large layer (999 TiB), then verifies that bootc switch fails
+# with "Insufficient free space" before attempting to fetch any data.
+use std assert
+use tap.nu
+
+tap begin "pre-flight disk space check"
+
+def main [] {
+    let td = mktemp -d
+
+    # --- Build a minimal but valid fake OCI image layout ---
+    #
+    # The config blob must be real (containers-image-proxy fetches it to
+    # parse ImageConfiguration).  The layer blob need not exist because
+    # the disk-space check fires before any layer is fetched.
+
+    # Minimal OCI image config (empty rootfs, no layers referenced inside config)
+    # The config must include a bootable label ("containers.bootc" or "ostree.bootable")
+    # so that bootc's require_bootable() check in prepare() passes.
+    let config_content = '{"architecture":"amd64","os":"linux","config":{"Labels":{"containers.bootc":"1"}},"rootfs":{"type":"layers","diff_ids":[]},"history":[{"created_by":"fake layer"}]}'
+    let config_digest = $config_content | hash sha256
+    let config_size = ($config_content | str length)
+
+    # Write config blob
+    mkdir $"($td)/blobs/sha256"
+    $config_content | save $"($td)/blobs/sha256/($config_digest)"
+
+    # Fake layer: a digest that points to a non-existent blob is fine because
+    # the preflight check reads the declared size from the manifest only.
+    let fake_layer_digest = "0000000000000000000000000000000000000000000000000000000000000000"
+    let fake_layer_size = 999_999_999_999_999  # ~999 TiB — will never fit on disk
+
+    # OCI image manifest pointing to the real config + one fake large layer
+    let manifest_content = $'{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:($config_digest)","size":($config_size)},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:($fake_layer_digest)","size":($fake_layer_size)}]}'
+    let manifest_digest = $manifest_content | hash sha256
+    let manifest_size = ($manifest_content | str length)
+
+    # Write manifest blob
+    $manifest_content | save $"($td)/blobs/sha256/($manifest_digest)"
+
+    # OCI layout marker
+    '{"imageLayoutVersion":"1.0.0"}' | save $"($td)/oci-layout"
+
+    # Index pointing to our manifest
+    let index_content = $'{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:($manifest_digest)","size":($manifest_size)}]}'
+    $index_content | save $"($td)/index.json"
+
+    # --- Attempt bootc switch; expect pre-flight failure ---
+    let result = do { bootc switch --transport oci $td } | complete
+    print $"exit_code: ($result.exit_code)"
+    print $"stderr: ($result.stderr)"
+
+    assert ($result.exit_code != 0) "bootc switch should have failed due to insufficient disk space"
+    assert ($result.stderr | str contains "Insufficient free space") $"Expected 'Insufficient free space' in stderr, got: ($result.stderr)"
+
+    tap ok
+}
+
+main

--- a/tmt/tests/tests.fmf
+++ b/tmt/tests/tests.fmf
@@ -102,6 +102,11 @@
   duration: 10m
   test: python3 booted/test-user-agent.py
 
+/test-35-upgrade-preflight-disk-check:
+  summary: Verify pre-flight disk space check rejects images with inflated layer sizes
+  duration: 20m
+  test: nu booted/test-upgrade-preflight-disk-check.nu
+
 /test-36-rollback:
   summary: Test bootc rollback functionality through image switch and rollback cycle
   duration: 30m


### PR DESCRIPTION
Extends PR #1245's approach to all bootc upgrade modes that download layers (default, --apply, --download-only). Moves check_disk_space() to deploy.rs for reuse by both install and upgrade operations.

This prevents wasted bandwidth and provides immediate feedback when insufficient disk space is available, matching the install behavior.

Related: BIFROST-1088

Assisted-by: AI