### PR TITLE
install-to-filesystem: Allow /boot to be missing in target

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -2409,15 +2409,15 @@ pub(crate) async fn install_to_filesystem(
     tracing::debug!("Root mount: {} {:?}", root_info.mount_spec, root_info.kargs);
 
     let boot_is_mount = {
-        let root_dev = rootfs_fd.dir_metadata()?.dev();
-        let boot_dev = target_rootfs_fd
-            .symlink_metadata_optional(BOOT)?
-            .ok_or_else(|| {
-                anyhow!("No /{BOOT} directory found in root; this is is currently required")
-            })?
-            .dev();
-        tracing::debug!("root_dev={root_dev} boot_dev={boot_dev}");
-        root_dev != boot_dev
+        if let Some(boot_metadata) = target_rootfs_fd.symlink_metadata_optional(BOOT)? {
+            let root_dev = rootfs_fd.dir_metadata()?.dev();
+            let boot_dev = boot_metadata.dev();
+            tracing::debug!("root_dev={root_dev} boot_dev={boot_dev}");
+            root_dev != boot_dev
+        } else {
+            tracing::debug!("No /{BOOT} directory found");
+            false
+        }
     };
     // Find the UUID of /boot because we need it for GRUB.
     let boot_uuid = if boot_is_mount {


### PR DESCRIPTION
When we're currently checking if /boot is a mountpoint we ware failing if /boot is missing. In the automotive usecase, with aboot, neither /boot or /boot/EFI are real partitions, so when bootc-immage-builder runs there will be no mounts anywhere under /boot, which means bootc errors out with:

```
No /boot directory found in root; this is is currently required.
```

This isn't necessary, we can just continue on with boot_is_mount as false in this case.

Note: Things later fail in bootupd, but that can be fixed separately.