### PR TITLE
store: Centralize composefs directory creation with mode 0700

### DIFF
--- a/crates/lib/src/bootc_composefs/repo.rs
+++ b/crates/lib/src/bootc_composefs/repo.rs
@@ -26,9 +26,7 @@ pub(crate) async fn initialize_composefs_repository(
 ) -> Result<(String, impl FsVerityHashValue)> {
     let rootfs_dir = &root_setup.physical_root;
 
-    rootfs_dir
-        .create_dir_all("composefs")
-        .context("Creating dir composefs")?;
+    crate::store::ensure_composefs_dir(rootfs_dir)?;
 
     let repo = open_composefs_repo(rootfs_dir)?;
 


### PR DESCRIPTION
The install-time composefs directory creation in repo.rs used
create_dir_all() which relies on the process umask for permissions,
potentially creating /sysroot/composefs with overly permissive modes
and leaking information.

Centralize the directory creation into a new ensure_composefs_dir()
helper in store/mod.rs that explicitly sets mode 0700. Both the
install-time path (repo.rs) and the runtime lazy-init path
(Storage::get_ensure_composefs) now use this single helper.

Also removes #[allow(dead_code)] from COMPOSEFS_MODE since it is now
actively used, and adds a unit test verifying the directory permissions
and idempotency.

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
