### PR TITLE
tmt: Temporarily disable unified storage test

### DIFF
--- a/tmt/tests/booted/test-switch-to-unified.nu
+++ b/tmt/tests/booted/test-switch-to-unified.nu
@@ -17,6 +17,10 @@ let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
 def main [] {
+  # TODO: This test is temporarily disabled, see https://github.com/bootc-dev/bootc/pull/1986
+  print "Test disabled, returning early with success."
+  return
+
   match $env.TMT_REBOOT_COUNT? {
     null | "0" => first_boot,
     "1" => second_boot,


### PR DESCRIPTION
There's something weird going on with selinux labeling, see discussion
at:

https://github.com/bootc-dev/bootc/pull/1986

Disable the test for now while we troubleshoot, because it's blocking
other stuff that needs to merge.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
