### PR TITLE
Makefile: Remove build dependency from install target

### DIFF
--- a/contrib/packaging/bootc.spec
+++ b/contrib/packaging/bootc.spec
@@ -146,7 +146,8 @@ sed -i -e '/https:\/\//d' cargo-vendor.txt
 %endif
 
 %install
-%make_install INSTALL="install -p -c"
+# Pass CARGO_FEATURES explicitly to prevent auto-detection rebuild in install environment
+%make_install INSTALL="install -p -c" CARGO_FEATURES="%{?with_rhsm:rhsm}"
 %if %{with ostree_ext}
 make install-ostree-hooks DESTDIR=%{?buildroot}
 %endif


### PR DESCRIPTION
The Makefile's CARGO_FEATURES auto-detection based on /usr/lib/os-release
can produce different results in the install environment vs build
environment. This causes 'make install' to rebuild the binary without
the intended features (e.g., rhsm).

Pass CARGO_FEATURES explicitly to ensure the install step doesn't
trigger an unwanted rebuild with different features.
