### PR TITLE
podstorage: Relabel storage after podman write operations

### DIFF
--- a/tmt/tests/booted/test-switch-to-unified.nu
+++ b/tmt/tests/booted/test-switch-to-unified.nu
@@ -17,10 +17,6 @@ let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
 def main [] {
-  # TODO: This test is temporarily disabled, see https://github.com/bootc-dev/bootc/pull/1986
-  print "Test disabled, returning early with success."
-  return
-
   match $env.TMT_REBOOT_COUNT? {
     null | "0" => first_boot,
     "1" => second_boot,


### PR DESCRIPTION
Files written by podman into the bootc-owned container storage get
incorrect SELinux labels because neither the on-disk path
(/sysroot/ostree/bootc/storage) nor the bind-mount path
(/run/bootc/storage) has file context rules in the system SELinux
policy. The existing ensure_labeled() mechanism only ran once at
storage creation time via a stamp file, so all files created by
subsequent podman operations (image layers, metadata, etc.) were
mislabeled, causing container execution failures like:

  /bin/sh: error while loading shared libraries: /lib64/libc.so.6:
  cannot apply additional memory protection after relocation:
  Permission denied

Fix this by storing the SELinux policy in CStorage and recursively
relabeling all files as if they lived under /var/lib/containers/storage
after every podman write operation (pull, pull_from_host_storage, and
imgcmd_entrypoint for build/pull commands).

Also re-enable the unified storage integration test that was disabled
in c26ae5aa while this was being investigated.

Closes: #2020
Assisted-by: OpenCode (claude-opus-4-6)
