### PR TITLE
install: Defer SELinux relabeling of container storage until after image pulls

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1931,6 +1931,10 @@ async fn ostree_install(state: &State, rootfs: &RootSetup, cleanup: Cleanup) -> 
             sysroot_dir.atomic_write(DESTRUCTIVE_CLEANUP, b"")?;
         }
 
+        // Ensure the image storage is SELinux-labeled. This must happen
+        // after all image pulls are complete.
+        sysroot.ensure_imgstore_labeled()?;
+
         // We must drop the sysroot here in order to close any open file
         // descriptors.
     };

--- a/crates/lib/src/install/completion.rs
+++ b/crates/lib/src/install/completion.rs
@@ -315,10 +315,12 @@ pub(crate) async fn impl_completion(
 
         // When we're run through ostree, we only lazily initialize the podman storage to avoid
         // having a hard dependency on it.
-        let imgstorage = &CStorage::create(&sysroot_dir, &rundir, sepolicy.as_ref())?;
-        crate::boundimage::pull_images_impl(imgstorage, bound_images)
+        let imgstorage = CStorage::create(&sysroot_dir, &rundir, sepolicy.as_ref())?;
+        crate::boundimage::pull_images_impl(&imgstorage, bound_images)
             .await
             .context("pulling bound images")?;
+        // Ensure the image storage is SELinux-labeled after all pulls are complete.
+        imgstorage.ensure_labeled()?;
     }
 
     // Log completion success

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -414,6 +414,15 @@ impl Storage {
         Ok(self.imgstore.get_or_init(|| imgstore))
     }
 
+    /// Ensure the image storage is properly SELinux-labeled. This should be
+    /// called after all image pulls are complete.
+    pub(crate) fn ensure_imgstore_labeled(&self) -> Result<()> {
+        if let Some(imgstore) = self.imgstore.get() {
+            imgstore.ensure_labeled()?;
+        }
+        Ok(())
+    }
+
     /// Access the composefs repository; will automatically initialize it if necessary.
     ///
     /// This lazily opens the composefs repository, creating the directory if needed

--- a/tmt/tests/booted/test-switch-to-unified.nu
+++ b/tmt/tests/booted/test-switch-to-unified.nu
@@ -17,10 +17,6 @@ let st = bootc status --json | from json
 let booted = $st.status.booted.image
 
 def main [] {
-  # TODO: This test is temporarily disabled, see https://github.com/bootc-dev/bootc/pull/1986
-  print "Test disabled, returning early with success."
-  return
-
   match $env.TMT_REBOOT_COUNT? {
     null | "0" => first_boot,
     "1" => second_boot,


### PR DESCRIPTION
Previously, the bootc-owned containers-storage instance was SELinux-relabeled
immediately upon creation in CStorage::create(), before any logically bound
images (LBIs) were pulled into it. When bootc install runs inside a VM with
SELinux disabled (e.g. bcvk ephemeral mode passes selinux=0 on the kernel
command line), all files created during the install are unlabeled. The early
relabel only covered the empty storage scaffold, while LBI content pulled
afterward remained unlabeled. The .bootc_labeled stamp file then prevented
re-relabeling.

Fix this by splitting the behavior in CStorage::create(): when opening
pre-existing storage (the booted/runtime case), ensure_labeled() is called
immediately as before. When creating fresh storage (the install case),
labeling is deferred. The install and completion code paths now call
ensure_labeled() explicitly after all image pulls are complete, ensuring
all content is covered by the relabel pass.

The SELinux policy is stored in CStorage at creation time so that
ensure_labeled() can be called without needing the policy from the caller.

This also reverts the test disablement from PR#2014, re-enabling
test-switch-to-unified.nu.

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>