### PR TITLE
Move blockdev code from bootupd into blockdev crate

### DIFF
--- a/crates/blockdev/src/blockdev.rs
+++ b/crates/blockdev/src/blockdev.rs
@@ -279,34 +279,48 @@ impl Device {
         }
     }
 
-    /// Walk the parent chain to find the root (whole disk) device.
+    /// Walk the parent chain to find all root (whole disk) devices,
+    /// and fail if more than one root is found.
     ///
-    /// Returns the root device with its children (partitions) populated.
-    /// If this device is already a root device, returns a clone of `self`.
-    /// Fails if the device has multiple parents at any level.
-    pub fn root_disk(&self) -> Result<Device> {
+    /// This is a convenience wrapper around `find_all_roots` for callers
+    /// that expect exactly one backing device (e.g. non-RAID setups).
+    pub fn require_single_root(&self) -> Result<Device> {
+        let mut roots = self.find_all_roots()?;
+        match roots.len() {
+            1 => Ok(roots.remove(0)),
+            n => anyhow::bail!(
+                "Expected a single root device for {}, but found {n}",
+                self.path()
+            ),
+        }
+    }
+
+    /// Walk the parent chain to find all root (whole disk) devices.
+    ///
+    /// Returns all root devices with their children (partitions) populated.
+    /// This handles devices backed by multiple parents (e.g. RAID arrays)
+    /// by following all branches of the parent tree.
+    /// If this device is already a root device, returns a single-element list.
+    pub fn find_all_roots(&self) -> Result<Vec<Device>> {
         let Some(parents) = self.list_parents()? else {
             // Already a root device; re-query to ensure children are populated
-            return list_dev(Utf8Path::new(&self.path()));
+            return Ok(vec![list_dev(Utf8Path::new(&self.path()))?]);
         };
-        let mut current = parents;
-        loop {
-            anyhow::ensure!(
-                current.len() == 1,
-                "Device {} has multiple parents; cannot determine root disk",
-                self.path()
-            );
-            let mut parent = current.into_iter().next().unwrap();
-            match parent.children.take() {
+
+        let mut roots = Vec::new();
+        let mut queue = parents;
+        while let Some(mut device) = queue.pop() {
+            match device.children.take() {
                 Some(grandparents) if !grandparents.is_empty() => {
-                    current = grandparents;
+                    queue.extend(grandparents);
                 }
                 _ => {
-                    // Found the root; re-query to populate its actual children
-                    return list_dev(Utf8Path::new(&parent.path()));
+                    // Found a root; re-query to populate its actual children
+                    roots.push(list_dev(Utf8Path::new(&device.path()))?);
                 }
             }
         }
+        Ok(roots)
     }
 }
 

--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -545,7 +545,8 @@ pub(crate) fn setup_composefs_bls_boot(
             cmdline.add_or_modify(&param);
 
             // Locate ESP partition device
-            let root_dev = bootc_blockdev::list_dev_by_dir(&storage.physical_root)?.root_disk()?;
+            let root_dev =
+                bootc_blockdev::list_dev_by_dir(&storage.physical_root)?.require_single_root()?;
             let esp_dev = root_dev.find_partition_of_esp()?;
 
             (
@@ -1083,7 +1084,8 @@ pub(crate) fn setup_composefs_uki_boot(
             let bootloader = host.require_composefs_booted()?.bootloader.clone();
 
             // Locate ESP partition device
-            let root_dev = bootc_blockdev::list_dev_by_dir(&storage.physical_root)?.root_disk()?;
+            let root_dev =
+                bootc_blockdev::list_dev_by_dir(&storage.physical_root)?.require_single_root()?;
             let esp_dev = root_dev.find_partition_of_esp()?;
 
             (
@@ -1255,7 +1257,10 @@ pub(crate) async fn setup_composefs_boot(
 
     if cfg!(target_arch = "s390x") {
         // TODO: Integrate s390x support into install_via_bootupd
-        crate::bootloader::install_via_zipl(&root_setup.device_info, boot_uuid)?;
+        crate::bootloader::install_via_zipl(
+            &root_setup.device_info.require_single_root()?,
+            boot_uuid,
+        )?;
     } else if postfetch.detected_bootloader == Bootloader::Grub {
         crate::bootloader::install_via_bootupd(
             &root_setup.device_info,

--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -45,7 +45,7 @@ pub(crate) fn mount_esp_part(root: &Dir, root_path: &Utf8Path, is_ostree: bool) 
         root
     };
 
-    let dev = bootc_blockdev::list_dev_by_dir(physical_root)?.root_disk()?;
+    let dev = bootc_blockdev::list_dev_by_dir(physical_root)?.require_single_root()?;
     if let Some(esp_dev) = dev.find_partition_of_type(bootc_blockdev::ESP) {
         let esp_path = esp_dev.path();
         bootc_mount::mount(&esp_path, &root_path.join(&efi_path))?;

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1795,7 +1795,8 @@ async fn install_with_sysroot(
 
     if cfg!(target_arch = "s390x") {
         // TODO: Integrate s390x support into install_via_bootupd
-        crate::bootloader::install_via_zipl(&rootfs.device_info, boot_uuid)?;
+        // zipl only supports single device
+        crate::bootloader::install_via_zipl(&rootfs.device_info.require_single_root()?, boot_uuid)?;
     } else {
         match postfetch.detected_bootloader {
             Bootloader::Grub => {
@@ -2514,7 +2515,8 @@ pub(crate) async fn install_to_filesystem(
     // Find the real underlying backing device for the root.  This is currently just required
     // for GRUB (BIOS) and in the future zipl (I think).
     let device_info = {
-        let dev = bootc_blockdev::list_dev(Utf8Path::new(&inspect.source))?.root_disk()?;
+        let dev =
+            bootc_blockdev::list_dev(Utf8Path::new(&inspect.source))?.require_single_root()?;
         tracing::debug!("Backing device: {}", dev.path());
         dev
     };

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -196,7 +196,8 @@ impl BootedStorage {
                 let composefs = Arc::new(composefs);
 
                 //TODO: this assumes a single ESP on the root device
-                let root_dev = bootc_blockdev::list_dev_by_dir(&physical_root)?.root_disk()?;
+                let root_dev =
+                    bootc_blockdev::list_dev_by_dir(&physical_root)?.require_single_root()?;
                 let esp_dev = root_dev.find_partition_of_esp()?;
                 let esp_mount = mount_esp(&esp_dev.path())?;
 


### PR DESCRIPTION
Consolidating the blockdev code that was scattered across bootupd and bootc into the blockdev crate. This is prep and cleanup for multi device parent support in bootupd. This needs to be merged before the bootupd changes can be merged.  Then, after the multi device support changes to bootupd are merged, I'll open another PR against bootc to integrate with the multi device bootupd changes.