### PR TITLE
Update to latest composefs-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bootc-kernel-cmdline",
+ "cfsctl",
  "clap",
- "composefs",
- "composefs-boot",
  "fn-error-context",
  "libc",
  "rustix",
@@ -269,9 +268,6 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "comfy-table",
- "composefs",
- "composefs-boot",
- "composefs-oci",
  "etc-merge",
  "fn-error-context",
  "hex",
@@ -584,7 +580,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfsctl"
 version = "0.3.0"
-source = "git+https://github.com/composefs/composefs-rs?rev=b928c6bd6c051e111d3efc3d25cdaf9159182ed0#b928c6bd6c051e111d3efc3d25cdaf9159182ed0"
+source = "git+https://github.com/composefs/composefs-rs?rev=2203e8f#2203e8f331cc41afafa0f81e9a2df7d681e9f631"
 dependencies = [
  "anyhow",
  "clap",
@@ -711,7 +707,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/composefs/composefs-rs?rev=b928c6bd6c051e111d3efc3d25cdaf9159182ed0#b928c6bd6c051e111d3efc3d25cdaf9159182ed0"
+source = "git+https://github.com/composefs/composefs-rs?rev=2203e8f#2203e8f331cc41afafa0f81e9a2df7d681e9f631"
 dependencies = [
  "anyhow",
  "composefs-ioctls",
@@ -733,7 +729,7 @@ dependencies = [
 [[package]]
 name = "composefs-boot"
 version = "0.3.0"
-source = "git+https://github.com/composefs/composefs-rs?rev=b928c6bd6c051e111d3efc3d25cdaf9159182ed0#b928c6bd6c051e111d3efc3d25cdaf9159182ed0"
+source = "git+https://github.com/composefs/composefs-rs?rev=2203e8f#2203e8f331cc41afafa0f81e9a2df7d681e9f631"
 dependencies = [
  "anyhow",
  "composefs",
@@ -747,7 +743,7 @@ dependencies = [
 [[package]]
 name = "composefs-ioctls"
 version = "0.3.0"
-source = "git+https://github.com/composefs/composefs-rs?rev=b928c6bd6c051e111d3efc3d25cdaf9159182ed0#b928c6bd6c051e111d3efc3d25cdaf9159182ed0"
+source = "git+https://github.com/composefs/composefs-rs?rev=2203e8f#2203e8f331cc41afafa0f81e9a2df7d681e9f631"
 dependencies = [
  "rustix",
  "thiserror 2.0.17",
@@ -756,7 +752,7 @@ dependencies = [
 [[package]]
 name = "composefs-oci"
 version = "0.3.0"
-source = "git+https://github.com/composefs/composefs-rs?rev=b928c6bd6c051e111d3efc3d25cdaf9159182ed0#b928c6bd6c051e111d3efc3d25cdaf9159182ed0"
+source = "git+https://github.com/composefs/composefs-rs?rev=2203e8f#2203e8f331cc41afafa0f81e9a2df7d681e9f631"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1146,7 +1142,7 @@ dependencies = [
  "anstream 1.0.0",
  "anyhow",
  "cap-std-ext 5.1.1",
- "composefs",
+ "cfsctl",
  "fn-error-context",
  "hex",
  "openssl",
@@ -2078,13 +2074,11 @@ dependencies = [
  "camino",
  "canon-json",
  "cap-std-ext 5.1.1",
+ "cfsctl",
  "chrono",
  "clap",
  "clap_mangen",
  "comfy-table",
- "composefs",
- "composefs-boot",
- "composefs-oci",
  "containers-image-proxy",
  "flate2",
  "fn-error-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,19 +40,11 @@ cfg-if = "1.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.4"
 clap_mangen = { version = "0.2.20" }
-# Reviewers (including AI tools): The composefs-rs git revision is duplicated for each crate.
-# If adding/removing crates here, also update docs/Dockerfile.mdbook and docs/src/internals.md.
-#
 # To develop against a local composefs-rs checkout, add a [patch] section at the end of this file:
-#   [patch."https://github.com/containers/composefs-rs"]
-#   composefs = { path = "/home/user/src/composefs-rs/crates/composefs" }
-#   composefs-boot = { path = "/home/user/src/composefs-rs/crates/composefs-boot" }
-#   composefs-oci = { path = "/home/user/src/composefs-rs/crates/composefs-oci" }
+#   [patch."https://github.com/composefs/composefs-rs"]
+#   cfsctl = { path = "/path/to/composefs-rs/crates/cfsctl" }
 # The Justfile will auto-detect these and bind-mount them into container builds.
-composefs = { git = "https://github.com/composefs/composefs-rs", rev = "b928c6bd6c051e111d3efc3d25cdaf9159182ed0", package = "composefs", features = ["rhel9"] }
-cfsctl = { git = "https://github.com/composefs/composefs-rs", rev = "b928c6bd6c051e111d3efc3d25cdaf9159182ed0", package = "cfsctl", features = ["rhel9"] }
-composefs-boot = { git = "https://github.com/composefs/composefs-rs", rev = "b928c6bd6c051e111d3efc3d25cdaf9159182ed0", package = "composefs-boot" }
-composefs-oci = { git = "https://github.com/composefs/composefs-rs", rev = "b928c6bd6c051e111d3efc3d25cdaf9159182ed0", package = "composefs-oci" }
+cfsctl = { git = "https://github.com/composefs/composefs-rs", rev = "2203e8f", package = "cfsctl", features = ["rhel9"] }
 fn-error-context = "0.2.1"
 hex = "0.4.3"
 indicatif = "0.18.0"

--- a/crates/etc-merge/Cargo.toml
+++ b/crates/etc-merge/Cargo.toml
@@ -12,7 +12,7 @@ rustix = { workspace = true }
 openssl = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
-composefs = { workspace = true }
+cfsctl = { workspace = true }
 fn-error-context = { workspace = true }
 owo-colors = { workspace = true }
 anstream = { workspace = true }

--- a/crates/etc-merge/src/lib.rs
+++ b/crates/etc-merge/src/lib.rs
@@ -17,6 +17,7 @@ use anyhow::Context;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::{Dir as CapStdDir, MetadataExt, Permissions, PermissionsExt};
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cfsctl::composefs;
 use composefs::fsverity::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
 use composefs::generic_tree::{Directory, Inode, Leaf, LeafContent, Stat};
 use composefs::tree::ImageError;

--- a/crates/initramfs/Cargo.toml
+++ b/crates/initramfs/Cargo.toml
@@ -11,8 +11,7 @@ clap = { workspace = true, features = ["std", "help", "usage", "derive"] }
 libc.workspace = true
 rustix.workspace = true
 serde = { workspace = true, features = ["derive"] }
-composefs.workspace = true
-composefs-boot.workspace = true
+cfsctl.workspace = true
 toml.workspace = true
 fn-error-context.workspace = true
 bootc-kernel-cmdline =  { path = "../kernel_cmdline", version = "0.0.0" }
@@ -22,5 +21,5 @@ workspace = true
 
 [features]
 default = ['pre-6.15']
-rhel9 = ['composefs/rhel9']
-'pre-6.15' = ['composefs/pre-6.15']
+rhel9 = ['cfsctl/rhel9']
+'pre-6.15' = ['cfsctl/pre-6.15']

--- a/crates/initramfs/src/lib.rs
+++ b/crates/initramfs/src/lib.rs
@@ -21,6 +21,8 @@ use rustix::{
 };
 use serde::Deserialize;
 
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
 use composefs::{
     fsverity::{FsVerityHashValue, Sha512HashValue},
     mount::FsHandle,

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -35,10 +35,7 @@ chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive","cargo"] }
 clap_complete = "4"
 clap_mangen = { workspace = true, optional = true }
-composefs = { workspace = true }
 cfsctl = { workspace = true }
-composefs-boot = { workspace = true }
-composefs-oci = { workspace = true }
 fn-error-context = { workspace = true }
 hex = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -74,19 +74,21 @@ use cap_std_ext::{
     cap_std::{ambient_authority, fs::Dir},
     dirext::CapStdExtDirExt,
 };
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
+use cfsctl::composefs_oci;
 use clap::ValueEnum;
 use composefs::fs::read_file;
+use composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
 use composefs::tree::RegularFile;
 use composefs_boot::BootOps;
-use composefs_boot::bootloader::{EFI_ADDON_DIR_EXT, EFI_ADDON_FILE_EXT, EFI_EXT, PEType};
-use fn_error_context::context;
-use ostree_ext::composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
-use ostree_ext::composefs_boot::bootloader::UsrLibModulesVmlinuz;
-use ostree_ext::composefs_boot::{
-    bootloader::BootEntry as ComposefsBootEntry, cmdline::get_cmdline_composefs,
-    os_release::OsReleaseInfo, uki,
+use composefs_boot::bootloader::{
+    BootEntry as ComposefsBootEntry, EFI_ADDON_DIR_EXT, EFI_ADDON_FILE_EXT, EFI_EXT, PEType,
+    UsrLibModulesVmlinuz,
 };
-use ostree_ext::composefs_oci::image::create_filesystem as create_composefs_filesystem;
+use composefs_boot::{cmdline::get_cmdline_composefs, os_release::OsReleaseInfo, uki};
+use composefs_oci::image::create_filesystem as create_composefs_filesystem;
+use fn_error_context::context;
 use rustix::{mount::MountFlags, path::Arg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -333,10 +335,10 @@ fn compute_boot_digest(
 /// * repo - The composefs repository
 #[context("Computing boot digest")]
 pub(crate) fn compute_boot_digest_uki(uki: &[u8]) -> Result<String> {
-    let vmlinuz = composefs_boot::uki::get_section(uki, ".linux")
-        .ok_or_else(|| anyhow::anyhow!(".linux not present"))??;
+    let vmlinuz =
+        uki::get_section(uki, ".linux").ok_or_else(|| anyhow::anyhow!(".linux not present"))??;
 
-    let initramfs = composefs_boot::uki::get_section(uki, ".initrd")
+    let initramfs = uki::get_section(uki, ".initrd")
         .ok_or_else(|| anyhow::anyhow!(".initrd not present"))??;
 
     let mut hasher = openssl::hash::Hasher::new(openssl::hash::MessageDigest::sha256())

--- a/crates/lib/src/bootc_composefs/digest.rs
+++ b/crates/lib/src/bootc_composefs/digest.rs
@@ -8,6 +8,8 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
 use composefs::dumpfile;
 use composefs::fsverity::FsVerityHashValue;
 use composefs_boot::BootOps as _;

--- a/crates/lib/src/bootc_composefs/export.rs
+++ b/crates/lib/src/bootc_composefs/export.rs
@@ -2,6 +2,8 @@ use std::{fs::File, os::fd::AsRawFd};
 
 use anyhow::{Context, Result};
 use cap_std_ext::cap_std::{ambient_authority, fs::Dir};
+use cfsctl::composefs;
+use cfsctl::composefs_oci;
 use composefs::splitstream::SplitStreamData;
 use composefs_oci::open_config;
 use ocidir::{OciDir, oci_spec::image::Platform};

--- a/crates/lib/src/bootc_composefs/finalize.rs
+++ b/crates/lib/src/bootc_composefs/finalize.rs
@@ -11,6 +11,7 @@ use bootc_initramfs_setup::mount_composefs_image;
 use bootc_mount::tempmount::TempMount;
 use cap_std_ext::cap_std::{ambient_authority, fs::Dir};
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cfsctl::composefs;
 use composefs::generic_tree::{Directory, Stat};
 use etc_merge::{compute_diff, merge, print_diff, traverse_etc};
 use rustix::fs::{fsync, renameat};

--- a/crates/lib/src/bootc_composefs/gc.rs
+++ b/crates/lib/src/bootc_composefs/gc.rs
@@ -6,6 +6,8 @@
 
 use anyhow::{Context, Result};
 use cap_std_ext::{cap_std::fs::Dir, dirext::CapStdExtDirExt};
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
 use composefs::repository::GcResult;
 use composefs_boot::bootloader::EFI_EXT;
 

--- a/crates/lib/src/bootc_composefs/repo.rs
+++ b/crates/lib/src/bootc_composefs/repo.rs
@@ -3,10 +3,13 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
-use ostree_ext::composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
-use ostree_ext::composefs_boot::{BootOps, bootloader::BootEntry as ComposefsBootEntry};
-use ostree_ext::composefs_oci::{
-    image::create_filesystem as create_composefs_filesystem, pull as composefs_oci_pull,
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
+use cfsctl::composefs_oci;
+use composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
+use composefs_boot::{BootOps, bootloader::BootEntry as ComposefsBootEntry};
+use composefs_oci::{
+    PullResult, image::create_filesystem as create_composefs_filesystem, pull as composefs_oci_pull,
 };
 
 use ostree_ext::container::ImageReference as OstreeExtImgRef;
@@ -24,7 +27,7 @@ pub(crate) async fn initialize_composefs_repository(
     state: &State,
     root_setup: &RootSetup,
     allow_missing_fsverity: bool,
-) -> Result<(String, impl FsVerityHashValue)> {
+) -> Result<PullResult<Sha512HashValue>> {
     const COMPOSEFS_REPO_INIT_JOURNAL_ID: &str = "5d4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9";
 
     let rootfs_dir = &root_setup.physical_root;
@@ -117,14 +120,14 @@ pub(crate) async fn pull_composefs_repo(
 
     tracing::debug!("Image to pull {final_imgref}");
 
-    let (id, verity) = composefs_oci_pull(&Arc::new(repo), &final_imgref, None, None)
+    let pull_result = composefs_oci_pull(&Arc::new(repo), &final_imgref, None, None)
         .await
         .context("Pulling composefs repo")?;
 
     tracing::info!(
         message_id = COMPOSEFS_PULL_JOURNAL_ID,
-        id = id,
-        verity = verity.to_hex(),
+        id = pull_result.config_digest,
+        verity = pull_result.config_verity.to_hex(),
         "Pulled image into repository"
     );
 
@@ -132,7 +135,7 @@ pub(crate) async fn pull_composefs_repo(
     repo.set_insecure(allow_missing_fsverity);
 
     let mut fs: crate::store::ComposefsFilesystem =
-        create_composefs_filesystem(&repo, &id, None)
+        create_composefs_filesystem(&repo, &pull_result.config_digest, None)
             .context("Failed to create composefs filesystem")?;
 
     let entries = fs.transform_for_boot(&repo)?;

--- a/crates/lib/src/bootc_composefs/state.rs
+++ b/crates/lib/src/bootc_composefs/state.rs
@@ -13,6 +13,7 @@ use canon_json::CanonJsonSerialize;
 use cap_std_ext::cap_std::ambient_authority;
 use cap_std_ext::cap_std::fs::{Dir, Permissions, PermissionsExt};
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cfsctl::composefs;
 use composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
 use fn_error_context::context;
 

--- a/crates/lib/src/bootc_composefs/update.rs
+++ b/crates/lib/src/bootc_composefs/update.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use cap_std_ext::{cap_std::fs::Dir, dirext::CapStdExtDirExt};
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
+use cfsctl::composefs_oci;
 use composefs::fsverity::{FsVerityHashValue, Sha512HashValue};
 use composefs_boot::BootOps;
 use composefs_oci::image::create_filesystem;

--- a/crates/lib/src/bootc_composefs/utils.rs
+++ b/crates/lib/src/bootc_composefs/utils.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::Result;
 use bootc_kernel_cmdline::utf8::Cmdline;
+use cfsctl::composefs_boot;
 use fn_error_context::context;
 
 fn get_uki(storage: &Storage, deployment_verity: &str) -> Result<Vec<u8>> {

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -12,19 +12,22 @@ use anyhow::{Context, Result, anyhow, ensure};
 use camino::{Utf8Path, Utf8PathBuf};
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
+use cfsctl::composefs;
+use cfsctl::composefs_boot;
+use cfsctl::composefs_oci;
 use clap::CommandFactory;
 use clap::Parser;
 use clap::ValueEnum;
 use composefs::dumpfile;
+use composefs::fsverity;
+use composefs::fsverity::FsVerityHashValue;
+use composefs::splitstream::SplitStreamWriter;
 use composefs_boot::BootOps as _;
 use etc_merge::{compute_diff, print_diff};
 use fn_error_context::context;
 use indoc::indoc;
 use ostree::gio;
 use ostree_container::store::PrepareResult;
-use ostree_ext::composefs::fsverity;
-use ostree_ext::composefs::fsverity::FsVerityHashValue;
-use ostree_ext::composefs::splitstream::SplitStreamWriter;
 use ostree_ext::container as ostree_container;
 
 use ostree_ext::keyfileext::KeyFileExt;
@@ -1611,12 +1614,15 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                 };
 
                 let imgref = format!("containers-storage:{image}");
-                let (imgid, verity) = composefs_oci::pull(&repo, &imgref, None, Some(proxycfg))
+                let pull_result = composefs_oci::pull(&repo, &imgref, None, Some(proxycfg))
                     .await
                     .context("Pulling image")?;
-                let imgid = hex::encode(imgid);
-                let mut fs = composefs_oci::image::create_filesystem(&repo, &imgid, Some(&verity))
-                    .context("Populating fs")?;
+                let mut fs = composefs_oci::image::create_filesystem(
+                    &repo,
+                    &pull_result.config_digest,
+                    Some(&pull_result.config_verity),
+                )
+                .context("Populating fs")?;
                 fs.transform_for_boot(&repo).context("Preparing for boot")?;
                 let id = fs.compute_image_id();
                 println!("{}", id.to_hex());

--- a/crates/lib/src/fsck.rs
+++ b/crates/lib/src/fsck.rs
@@ -16,10 +16,11 @@ use camino::Utf8PathBuf;
 use cap_std::fs::{Dir, MetadataExt as _};
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cfsctl::composefs;
 use fn_error_context::context;
 use linkme::distributed_slice;
+use ostree_ext::ostree;
 use ostree_ext::ostree_prepareroot::Tristate;
-use ostree_ext::{composefs, ostree};
 
 use crate::store::Storage;
 

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -201,6 +201,7 @@ use crate::task::Task;
 use crate::utils::sigpolicy_from_opt;
 use bootc_kernel_cmdline::{INITRD_ARG_PREFIX, ROOTFLAGS, bytes, utf8};
 use bootc_mount::Filesystem;
+use cfsctl::composefs;
 use composefs::fsverity::FsVerityHashValue;
 
 /// The toplevel boot directory
@@ -1952,18 +1953,22 @@ async fn install_to_filesystem_impl(
     if state.composefs_options.composefs_backend {
         // Load a fd for the mounted target physical root
 
-        let (id, verity) = initialize_composefs_repository(
+        let pull_result = initialize_composefs_repository(
             state,
             rootfs,
             state.composefs_options.allow_missing_verity,
         )
         .await?;
-        tracing::info!("id: {id}, verity: {}", verity.to_hex());
+        tracing::info!(
+            "id: {}, verity: {}",
+            pull_result.config_digest,
+            pull_result.config_verity.to_hex()
+        );
 
         setup_composefs_boot(
             rootfs,
             state,
-            &id,
+            &pull_result.config_digest,
             state.composefs_options.allow_missing_verity,
         )
         .await?;

--- a/crates/lib/src/kernel.rs
+++ b/crates/lib/src/kernel.rs
@@ -11,6 +11,7 @@ use bootc_kernel_cmdline::utf8::Cmdline;
 use camino::Utf8PathBuf;
 use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cfsctl::composefs_boot;
 use serde::Serialize;
 
 use crate::bootc_composefs::boot::EFI_LINUX;

--- a/crates/lib/src/parsers/bls_config.rs
+++ b/crates/lib/src/parsers/bls_config.rs
@@ -7,6 +7,7 @@
 use anyhow::{Result, anyhow};
 use bootc_kernel_cmdline::utf8::{Cmdline, CmdlineOwned};
 use camino::Utf8PathBuf;
+use cfsctl::composefs_boot;
 use composefs_boot::bootloader::EFI_EXT;
 use core::fmt;
 use std::collections::HashMap;

--- a/crates/lib/src/parsers/grub_menuconfig.rs
+++ b/crates/lib/src/parsers/grub_menuconfig.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
+use cfsctl::composefs_boot;
 use composefs_boot::bootloader::EFI_EXT;
 use nom::{
     Err, IResult, Parser,

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -36,6 +36,9 @@ use ostree_ext::sysroot::SysrootLock;
 use ostree_ext::{gio, ostree};
 use rustix::fs::Mode;
 
+use cfsctl::composefs;
+use composefs::fsverity::Sha512HashValue;
+
 use crate::bootc_composefs::boot::{EFI_LINUX, mount_esp};
 use crate::bootc_composefs::status::{ComposefsCmdline, composefs_booted, get_bootloader};
 use crate::lsm;
@@ -44,9 +47,9 @@ use crate::spec::{Bootloader, ImageStatus};
 use crate::utils::{deployment_fd, open_dir_remount_rw};
 
 /// See <https://github.com/containers/composefs-rs/issues/159>
-pub type ComposefsRepository =
-    composefs::repository::Repository<composefs::fsverity::Sha512HashValue>;
-pub type ComposefsFilesystem = composefs::tree::FileSystem<composefs::fsverity::Sha512HashValue>;
+pub type ComposefsRepository = composefs::repository::Repository<Sha512HashValue>;
+/// A composefs filesystem type alias
+pub type ComposefsFilesystem = composefs::tree::FileSystem<Sha512HashValue>;
 
 /// Path to the physical root
 pub const SYSROOT: &str = "sysroot";

--- a/crates/ostree-ext/Cargo.toml
+++ b/crates/ostree-ext/Cargo.toml
@@ -19,9 +19,7 @@ cap-std-ext = { workspace = true, features = ["fs_utf8"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive","cargo"] }
 clap_mangen = { workspace = true, optional = true }
-composefs = { workspace = true }
-composefs-boot = { workspace = true }
-composefs-oci = { workspace = true }
+cfsctl = { workspace = true }
 fn-error-context = { workspace = true }
 hex = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/ostree-ext/src/fsverity.rs
+++ b/crates/ostree-ext/src/fsverity.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
-use composefs::fsverity as composefs_fsverity;
+use cfsctl::composefs::fsverity as composefs_fsverity;
 use composefs_fsverity::Sha256HashValue;
 use ostree::gio;
 
@@ -63,7 +63,7 @@ fn enable_fsverity_in_objdir(d: &Dir) -> anyhow::Result<()> {
         };
         let f = d.open(&name)?;
         let enabled =
-            composefs::fsverity::measure_verity_opt::<Sha256HashValue>(f.as_fd())?.is_some();
+            composefs_fsverity::measure_verity_opt::<Sha256HashValue>(f.as_fd())?.is_some();
         if !enabled {
             // NOTE: We're not using the _with_copy API here because for us it'd require
             // copying all the metadata too which is mildly tedious.

--- a/crates/ostree-ext/src/lib.rs
+++ b/crates/ostree-ext/src/lib.rs
@@ -24,9 +24,9 @@
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
 // them needing to update matching versions.
-pub use composefs;
-pub use composefs_boot;
-pub use composefs_oci;
+pub use cfsctl::composefs;
+pub use cfsctl::composefs_boot;
+pub use cfsctl::composefs_oci;
 pub use containers_image_proxy;
 pub use containers_image_proxy::oci_spec;
 pub use ostree;

--- a/docs/Dockerfile.mdbook
+++ b/docs/Dockerfile.mdbook
@@ -23,7 +23,7 @@ set -xeuo pipefail
 # Build rustdoc for internal crates
 cargo doc --workspace --no-deps --document-private-items
 # Also build docs for key external git dependencies (not on docs.rs)
-cargo doc --no-deps --document-private-items -p composefs -p composefs-boot -p composefs-oci
+cargo doc --no-deps --document-private-items -p cfsctl
 # Build mdbook
 cd docs
 mdbook-mermaid install .

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -117,6 +117,4 @@ The following rustdoc documentation is generated from the source code with
 
 These crates are pulled from git and are not published to crates.io (so not on docs.rs).
 
-- [composefs](internals/composefs/index.html) - Core composefs library
-- [composefs-boot](internals/composefs_boot/index.html) - Boot support for composefs
-- [composefs-oci](internals/composefs_oci/index.html) - OCI integration for composefs
+- [cfsctl](internals/cfsctl/index.html) - composefs-rs entrypoint crate (re-exports composefs, composefs-boot, composefs-oci)


### PR DESCRIPTION
Using the new "single export from cfsctl" simplifies our Cargo.toml because we no longer need to reference the same git hash 3-4 times.