### PR TITLE
Release 1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "bootc-lib"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ platforms = ["*-unknown-linux-gnu"]
 
 [dependencies]
 # Internal crates
-bootc-lib = { version = "1.13", path = "../lib" }
+bootc-lib = { version = "1.14", path = "../lib" }
 bootc-utils = { package = "bootc-internal-utils", path = "../utils", version = "0.1.0" }
 
 # Workspace dependencies

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -6,7 +6,7 @@ name = "bootc-lib"
 repository = "https://github.com/bootc-dev/bootc"
 # The intention is we'll follow semver here, even though this
 # project isn't actually published as a crate.
-version = "1.13.0"
+version = "1.14.0"
 # In general we try to keep this pinned to what's in the latest RHEL9.
 rust-version = "1.85.0"
 


### PR DESCRIPTION
I can't force push to https://github.com/bootc-dev/bootc/pull/2052 (not sure why yet) so moving a conflict-free PR here