### PR TITLE
podstorage: fsync storage root before and after creating .bootc_labeled

### DIFF
--- a/crates/lib/src/podstorage.rs
+++ b/crates/lib/src/podstorage.rs
@@ -235,6 +235,14 @@ impl CStorage {
         )
         .context("labeling storage root")?;
 
+        // fsync so relabel writes are durable before creating the stamp file
+        rustix::fs::fsync(
+            self.storage_root
+                .reopen_as_ownedfd()
+                .context("Reopening as owned fd")?,
+        )
+        .context("fsync")?;
+
         self.storage_root.create(LABELED)?;
 
         // Label the stamp file itself to match the storage directory context
@@ -246,6 +254,14 @@ impl CStorage {
             sepolicy,
         )
         .context("labeling stamp file")?;
+
+        // fsync to persist the stamp file entry
+        rustix::fs::fsync(
+            self.storage_root
+                .reopen_as_ownedfd()
+                .context("Reopening as owned fd")?,
+        )
+        .context("fsync")?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds fsync calls to `ensure_labeled()` in podstorage to improve crash resilience around the `.bootc_labeled` stamp file, as suggested in #1210.

The storage root directory is synced after relabeling (so the label writes are durable before the stamp is created) and again after creating and labeling the stamp file (so the directory entry is persisted). This prevents a crash from leaving the system in a state where the stamp exists but the relabeling writes were lost, which would cause the relabeling to be silently skipped on next boot.

Uses the existing `reopen_as_ownedfd()` + `rustix::fs::fsync()` pattern to work around the O_PATH fd limitation on cap-std directories.

Closes #1210
