### PR TITLE
deploy: fix progress bar math for containers-storage transport

### DIFF
--- a/crates/lib/src/deploy.rs
+++ b/crates/lib/src/deploy.rs
@@ -234,11 +234,15 @@ async fn handle_layer_progress_print(mut config: LayerProgressConfig) -> Progres
                             bytes_total: layer_size,
                         };
                     } else {
-                        byte_bar.set_position(layer_size);
+                        // Use the bar's length (actual blob size) rather than
+                        // the manifest descriptor size for completion accounting.
+                        let actual_size = byte_bar.length().unwrap_or(layer_size);
+                        byte_bar.set_position(actual_size);
                         layers_bar.inc(1);
-                        total_read = total_read.saturating_add(layer_size);
+                        total_read = total_read.saturating_add(actual_size);
                         // Emit an event where bytes == total to signal completion.
-                        subtask.bytes = layer_size;
+                        subtask.bytes_total = actual_size;
+                        subtask.bytes = actual_size;
                         subtasks.push(subtask.clone());
                         config.prog.send(Event::ProgressBytes {
                             task: "pulling".into(),
@@ -268,7 +272,12 @@ async fn handle_layer_progress_print(mut config: LayerProgressConfig) -> Progres
                     bytes.as_ref().cloned()
                 };
                 if let Some(bytes) = bytes {
+                    // Update the bar length from the actual blob size, which
+                    // may differ from the manifest descriptor size (e.g.
+                    // containers-storage stores layers uncompressed).
+                    byte_bar.set_length(bytes.total);
                     byte_bar.set_position(bytes.fetched);
+                    subtask.bytes_total = bytes.total;
                     subtask.bytes = byte_bar.position();
                     config.prog.send_lossy(Event::ProgressBytes {
                         task: "pulling".into(),


### PR DESCRIPTION
When pulling from `containers-storage`, layers are stored uncompressed but the progress bar total was set from the manifest descriptor size (compressed). This caused the display to show transferred exceeding total, e.g. `2.66 GiB/1.14 GiB`.

The fix updates the byte progress bar length from `LayerProgress.total` on each progress update, which reflects the actual blob size for the current transport. For registry pulls this equals the manifest descriptor size (compressed), so the change is a no-op in that case. For `containers-storage` and `docker-daemon`, it uses the uncompressed size, matching what `ProgressReader` actually tracks.

Also updates the layer completion path to use the bar's actual length for `total_read` and subtask accounting, so that completion events report `bytes == bytes_total` consistently.

This aligns with how `ostree-ext`'s CLI handles the same progress (`cli.rs` already calls `pb.set_length(bytes.total)` before `pb.set_position(bytes.fetched)`).

Closes #2001
