### PR TITLE
initramfs: Inherit SELinux label on transient root tmpfs

### DIFF
--- a/crates/initramfs/Cargo.toml
+++ b/crates/initramfs/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+cap-std-ext.workspace = true
 clap = { workspace = true, features = ["std", "help", "usage", "derive"] }
 libc.workspace = true
 rustix.workspace = true

--- a/crates/initramfs/src/lib.rs
+++ b/crates/initramfs/src/lib.rs
@@ -1,7 +1,7 @@
 //! Mount helpers for bootc-initramfs
 
 use std::{
-    ffi::OsString,
+    ffi::{CString, OsString},
     fmt::Debug,
     io::ErrorKind,
     os::fd::{AsFd, AsRawFd, OwnedFd},
@@ -9,6 +9,8 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use cap_std_ext::cap_std::fs::Dir;
+use cap_std_ext::dirext::CapStdExtDirExt;
 use clap::Parser;
 use rustix::{
     fs::{CWD, Mode, OFlags, major, minor, mkdirat, openat, stat, symlink},
@@ -19,6 +21,7 @@ use rustix::{
     },
     path,
 };
+
 use serde::Deserialize;
 
 use cfsctl::composefs;
@@ -202,9 +205,21 @@ fn bind_mount(fd: impl AsFd, path: &str) -> Result<OwnedFd> {
     Ok(res?)
 }
 
-#[context("Mounting tmpfs")]
-fn mount_tmpfs() -> Result<OwnedFd> {
+/// Mount a tmpfs, inheriting the SELinux label from the base filesystem
+/// if provided. See <https://github.com/containers/bootc/issues/1992>.
+#[context("Mounting tmpfs for overlay")]
+fn mount_tmpfs_for_overlay(base: Option<impl AsFd>) -> Result<OwnedFd> {
     let tmpfs = FsHandle::open("tmpfs")?;
+
+    if let Some(base_fd) = base {
+        let base_dir = Dir::reopen_dir(&base_fd.as_fd())?;
+        if let Some(label) = base_dir.getxattr(".", "security.selinux")? {
+            if let Ok(cstr) = CString::new(label) {
+                fsconfig_set_string(tmpfs.as_fd(), "rootcontext", &cstr)?;
+            }
+        }
+    }
+
     fsconfig_create(tmpfs.as_fd())?;
     Ok(fsmount(
         tmpfs.as_fd(),
@@ -239,16 +254,20 @@ fn overlay_state(
     mount_at_wrapper(fs, base, ".").context("Moving mount")
 }
 
-/// Mounts a transient overlayfs with passed in fd as the lowerdir
+/// Mounts a transient overlayfs with passed in fd as the lowerdir.
+///
+/// The tmpfs used for the overlay upper layer inherits the SELinux label
+/// from the base filesystem to prevent label mismatches (see #1992).
 #[context("Mounting transient overlayfs")]
 pub fn overlay_transient(
     base: impl AsFd,
     mode: Option<rustix::fs::Mode>,
     mount_attr_flags: Option<MountAttrFlags>,
 ) -> Result<()> {
+    let tmpfs = mount_tmpfs_for_overlay(Some(&base))?;
     overlay_state(
         base,
-        prepare_mount(mount_tmpfs()?)?,
+        prepare_mount(tmpfs)?,
         "transient",
         mode,
         mount_attr_flags,


### PR DESCRIPTION
## Summary

When `root.transient` is enabled, the overlay root at `/` gets SELinux label
`tmpfs_t` instead of `root_t`, causing services like systemd-networkd to crash.

This PR fixes the composefs backend by reading the SELinux label from the lower
(composefs) filesystem and setting it as `rootcontext` on the tmpfs used for
the overlay upper layer.

## What changed

- New `mount_tmpfs_for_overlay()` that reads `security.selinux` xattr from the
  base filesystem and sets `rootcontext` on the tmpfs before overlay creation
- Uses the two-call `fgetxattr` pattern (query size → allocate → read) for
  correct handling of arbitrarily long MLS/MCS contexts
- Uses `CString` (not `str`) to avoid requiring UTF-8 labels
- Gracefully handles SELinux-disabled systems (fgetxattr error → no context set)
- `overlay_transient()` passes the base fd through to inherit the correct label
- Removed the now-unused `mount_tmpfs()` wrapper

## Design decisions

- **`rootcontext=` over `context=`**: `rootcontext` sets only the root inode's
  label, letting new files inherit labels from SELinux policy. `context=` would
  force a uniform label on all inodes in the tmpfs, which is too broad.
  (systemd uses `context=` in nspawn and has had issues with it — see
  systemd/systemd#12292.)

- **Read from lower layer, not hardcode**: The label is read from the composefs
  base filesystem rather than hardcoding `root_t`. This works regardless of the
  SELinux policy in use.

- **Silent fallback**: If SELinux is not enabled or the xattr read fails, no
  context is set and behavior is unchanged from before this patch.

## Related issues

- **ostree backend**: The ostree backend (`otcore-prepare-root.c`) has the same
  issue but uses `/run` as the tmpfs backing store. That fix would go through
  `lcfs_mount_options_s` in libcomposefs or the ostree repo. Happy to file a
  follow-up issue on ostreedev/ostree.

- **systemd**: `systemd.volatile=overlay` has the same unfixed bug
  (systemd/systemd#12292). Dan Walsh's fix attempt (systemd/systemd#26141) has
  been stalled since 2023.

## Testing

This runs in the initramfs before the real root is mounted, so testing requires
a VM with SELinux enforcing and `root.transient` enabled. Verification:

```bash
# Before fix: / has tmpfs_t
ls -Zd /
# system_u:object_r:tmpfs_t:s0 /

# After fix: / has root_t
ls -Zd /
# system_u:object_r:root_t:s0 /
```

Closes #1992

Signed-off-by: Andrew Dunn <andrew@dunn.dev>