### PR TITLE
tar: fix etc remapping of paths with non-ASCII characters

### DIFF
--- a/crates/ostree-ext/src/tar/write.rs
+++ b/crates/ostree-ext/src/tar/write.rs
@@ -53,17 +53,16 @@ pub(crate) fn copy_entry(
         // append_data/append_link. Keeping the originals would override our
         // remap (e.g. /etc -> /usr/etc) since PAX headers take precedence
         // over basic tar header fields per POSIX.
-        let extensions: Vec<_> = headers
-            .map(|ext| {
-                let ext = ext?;
-                Ok((ext.key()?, ext.value_bytes()))
-            })
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .filter(|(key, _)| *key != "path" && *key != "linkpath")
-            .collect();
-        if !extensions.is_empty() {
-            dest.append_pax_extensions(extensions.iter().copied())?;
+        let mut extensions_to_keep = Vec::new();
+        for ext_res in headers {
+            let ext = ext_res?;
+            let key = ext.key()?;
+            if key != "path" && key != "linkpath" {
+                extensions_to_keep.push((key, ext.value_bytes()));
+            }
+        }
+        if !extensions_to_keep.is_empty() {
+            dest.append_pax_extensions(extensions_to_keep)?;
         }
     }
 
@@ -681,7 +680,8 @@ mod tests {
                 found_remapped = true;
             }
             if let Some(pax) = entry.pax_extensions()? {
-                for ext in pax.flatten() {
+                for ext_res in pax {
+                    let ext = ext_res?;
                     if let Ok("path" | "linkpath") = ext.key() {
                         let value = String::from_utf8_lossy(ext.value_bytes());
                         let clean = value.trim_start_matches("./").trim_end_matches('\0');


### PR DESCRIPTION
PAX extended headers take precedence over basic tar header fields [per POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html). When a container layer contains PAX `path` or `linkpath` headers (e.g. for non-ASCII filenames), they override the remapped path written to the basic header, causing files that should land under `/usr/etc` to remain under `/etc`.

This PR filters out `path` and `linkpath` from PAX extensions in `copy_entry` before writing the output entry. The tar crate regenerates them from the remapped path passed to `append_data`/`append_link`. I also add a test to ensure that paths containing non-ASCII characters are remapped properly. 

Fixes https://github.com/bootcrew/ubuntu-bootc/issues/4 (I ran into the same issue building my own ubuntu-based bootc image).

Example error:
```
DEBUG Unpacking ce3df020c13aeeedc9f76a5c17ec16ad9cea07ebac153f28cc21de0df5a82d2f
DEBUG Unpacking 88a14deac5f276ea5cfafc9e60c0c8a23447c66ad06b0c8d4adbb15ee094e079
DEBUG Unpacking a87c799ffd61bc1624a71b732cc0ad4919c49cd924805e2f7d03b2d1883c67b0
DEBUG labeling from merged tree
DEBUG Removing usr/etc/resolv.conf
DEBUG Images found: 1
DEBUG Referenced layers: 23
DEBUG Found layers: 23
DEBUG pruned 0 layers
DEBUG Wrote merge commit 5f14c1364386257d9ca1ceff817c40c8b82393be4d8aec17beb06d269061f355
done (6 seconds)
error: Installing to disk: Creating ostree deployment: Performing deployment: Deploying tree: Initializing deployment: Preparing /etc: Tree contains both /etc and /usr/etc
Error: Process completed with exit code 1.
```

Disclaimer: This bug was quite hard to track down. I used claude to help find the root cause.