### PR TITLE
tmt: Disable rhel-ci AVC check for expected SELinux denials

### DIFF
--- a/tmt/plans/integration.fmf
+++ b/tmt/plans/integration.fmf
@@ -2,6 +2,12 @@
 provision:
   how: virtual
   image: $@{test_disk_image}
+# bootc probes for SELinux mac_admin/install_t capability by attempting
+# chcon with an intentionally invalid label (see lsm.rs test_install_t).
+# This generates expected AVC denials that rhel-ci's injected AVC check
+# would otherwise flag as test failures.
+environment:
+    AVC_ERROR: +no_avc_check
 prepare:
   # Install image mode system on package mode system
   # Do not run on image mode VM running on Github CI and Locally


### PR DESCRIPTION
We have a probe for `install_t` which causes an AVC denial. At some point we'll need to fix that, but for now
set AVC_ERROR=+no_avc_check in the integration plan environment to disable the check since it's gating in RHEL now.

Assisted-by: OpenCode (Claude Opus 4)