### PR TITLE
fix(composefs): merge default proxy opts for registry auth discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bootc-kernel-cmdline",
+ "cap-std-ext 5.1.1",
  "cfsctl",
  "clap",
  "fn-error-context",

--- a/crates/lib/src/bootc_composefs/repo.rs
+++ b/crates/lib/src/bootc_composefs/repo.rs
@@ -55,12 +55,15 @@ pub(crate) async fn initialize_composefs_repository(
         transport,
     } = &state.source.imageref;
 
+    let mut config = crate::deploy::new_proxy_config();
+    ostree_ext::container::merge_default_container_proxy_opts(&mut config)?;
+
     // transport's display is already of type "<transport_type>:"
     composefs_oci_pull(
         &Arc::new(repo),
         &format!("{transport}{image_name}"),
         None,
-        None,
+        Some(config),
     )
     .await
 }
@@ -120,7 +123,10 @@ pub(crate) async fn pull_composefs_repo(
 
     tracing::debug!("Image to pull {final_imgref}");
 
-    let pull_result = composefs_oci_pull(&Arc::new(repo), &final_imgref, None, None)
+    let mut config = crate::deploy::new_proxy_config();
+    ostree_ext::container::merge_default_container_proxy_opts(&mut config)?;
+
+    let pull_result = composefs_oci_pull(&Arc::new(repo), &final_imgref, None, Some(config))
         .await
         .context("Pulling composefs repo")?;
 

--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -317,7 +317,8 @@ pub(crate) fn list_bootloader_entries(storage: &Storage) -> Result<Vec<String>> 
 pub(crate) async fn get_container_manifest_and_config(
     imgref: &String,
 ) -> Result<ImgConfigManifest> {
-    let config = crate::deploy::new_proxy_config();
+    let mut config = crate::deploy::new_proxy_config();
+    ostree_ext::container::merge_default_container_proxy_opts(&mut config)?;
     let proxy = containers_image_proxy::ImageProxy::new_with_config(config).await?;
 
     let img = proxy


### PR DESCRIPTION
The composefs backend creates an `ImageProxyConfig` via `new_proxy_config()` in three places but never calls `merge_default_container_proxy_opts()`, so the global authfile (e.g. `/etc/ostree/auth.json`, `/usr/lib/ostree/auth.json`) is never discovered. This causes bootc upgrade, switch to fail with "access denied" on private registries when using the composefs backend.

The ostree backend handles this correctly via `ImageImporter::new()` which calls `merge_default_container_proxy_opts()` internally.

Maybe fixes https://github.com/bootc-dev/bootc/issues/2070 if the composefs backend was used there.