### PR TITLE
fix(install): set DM_DISABLE_UDEV=1 to prevent dm semaphore deadlock in container IPC namespace

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -5,6 +5,7 @@
 use std::ffi::{CString, OsStr, OsString};
 use std::fs::File;
 use std::io::{BufWriter, Seek};
+use std::os::fd::AsFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 
@@ -1514,6 +1515,23 @@ async fn usroverlay(access_mode: FilesystemOverlayAccessMode) -> Result<()> {
 /// in the standard `main` function.
 #[allow(unsafe_code)]
 pub fn global_init() -> Result<()> {
+    // Join the host IPC namespace if we're in an isolated one. Inside a
+    // container with a separate IPC namespace (the podman/docker default),
+    // udevd on the host cannot see the container's semaphores, causing
+    // cryptsetup operations to deadlock on semop(). The primary fix is to
+    // run the install container with --ipc=host; this is defense-in-depth
+    // for cases where the caller forgets that flag.
+    let ns_pid1 = std::fs::read_link("/proc/1/ns/ipc").context("reading /proc/1/ns/ipc")?;
+    let ns_self = std::fs::read_link("/proc/self/ns/ipc").context("reading /proc/self/ns/ipc")?;
+    if ns_pid1 != ns_self {
+        let pid1ipcns = std::fs::File::open("/proc/1/ns/ipc").context("open pid1 ipcns")?;
+        rustix::thread::move_into_link_name_space(
+            pid1ipcns.as_fd(),
+            Some(rustix::thread::LinkNameSpaceType::InterProcessCommunication),
+        )
+        .context("setns(ipc)")?;
+        tracing::debug!("Joined pid1 IPC namespace");
+    }
     // In some cases we re-exec with a temporary binary,
     // so ensure that the syslog identifier is set.
     ostree::glib::set_prgname(bootc_utils::NAME.into());

--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -60,7 +60,7 @@ to an existing system and install your container image. Failure to run
 Here's an example of using `bootc install` (root/elevated permission required):
 
 ```bash
-podman run --rm --privileged --pid=host -v /var/lib/containers:/var/lib/containers -v /dev:/dev --security-opt label=type:unconfined_t <image> bootc install to-disk /path/to/disk
+podman run --rm --privileged --pid=host --ipc=host -v /var/lib/containers:/var/lib/containers -v /dev:/dev --security-opt label=type:unconfined_t <image> bootc install to-disk /path/to/disk
 ```
 
 Note that while `--privileged` is used, this command will not perform any
@@ -68,7 +68,7 @@ destructive action on the host system.  Among other things, `--privileged`
 makes sure that all host devices are mounted into container. `/path/to/disk` is
 the host's block device where `<image>` will be installed on.
 
-The `--pid=host --security-opt label=type:unconfined_t` today
+The `--pid=host --ipc=host --security-opt label=type:unconfined_t` today
 make it more convenient for bootc to perform some privileged
 operations; in the future these requirements may be dropped.
 
@@ -191,7 +191,7 @@ process, you can create a raw disk image that you can boot via virtualization. R
 
 ```bash
 truncate -s 10G myimage.raw
-podman run --rm --privileged --pid=host --security-opt label=type:unconfined_t -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v .:/output <yourimage> bootc install to-disk --generic-image --via-loopback /output/myimage.raw
+podman run --rm --privileged --pid=host --ipc=host --security-opt label=type:unconfined_t -v /dev:/dev -v /var/lib/containers:/var/lib/containers -v .:/output <yourimage> bootc install to-disk --generic-image --via-loopback /output/myimage.raw
 ```
 
 Notice that we use `--generic-image` for this use case.


### PR DESCRIPTION
## Summary

Prevent the libdevmapper udev cookie semaphore deadlock that causes `cryptsetup luksOpen`/`luksClose` to hang inside containers with isolated IPC namespaces.

## Root cause

When `bootc install` runs inside a container (the standard invocation), the container has its own IPC namespace by default. libdevmapper creates System V semaphores ("udev cookies") to synchronize with udevd, but udevd runs in the host IPC namespace and can't see the container's semaphores. The `semop()` call blocks forever.

Full analysis: #2089

## Fix

Two changes, as suggested in review:

1. **`--ipc=host` in documented invocations** (primary fix): Add `--ipc=host` to the `podman run` commands in `bootc-install.md`. This shares the host IPC namespace so libdevmapper's semaphores reach udevd. We already pass `--pid=host` and propagate `/run`, so `--ipc=host` is consistent.

2. **`DM_DISABLE_UDEV=1` in `global_init()`** (defense-in-depth): Set the env var early in process initialization, alongside the existing `HOME` workaround. This tells libdevmapper to skip udev synchronization entirely, catching cases where IPC sharing is not configured.

Fixes: #2089
Related: #421
