### PR TITLE
composefs: add a systemd.mount-extra kernel argument to the BLS boot entry

### DIFF
--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -532,6 +532,22 @@ pub(crate) fn setup_composefs_bls_boot(
                 ComposefsCmdline::build(&id_hex, state.composefs_options.allow_missing_verity);
             cmdline_options.extend(&Cmdline::from(&composefs_cmdline.to_string()));
 
+            // If there's a separate /boot partition, add a systemd.mount-extra
+            // karg so systemd mounts it after reboot. This avoids writing to
+            // /etc/fstab which conflicts with transient etc (see #1388).
+            if let Some(boot) = root_setup.boot_mount_spec() {
+                if !boot.source.is_empty() {
+                    let mount_extra = format!(
+                        "systemd.mount-extra={}:/boot:{}:{}",
+                        boot.source,
+                        boot.fstype,
+                        boot.options.as_deref().unwrap_or("defaults"),
+                    );
+                    cmdline_options.extend(&Cmdline::from(mount_extra.as_str()));
+                    tracing::debug!("Added /boot mount karg: {mount_extra}");
+                }
+            }
+
             // Locate ESP partition device
             let esp_part = root_setup.device_info.find_partition_of_esp()?;
 

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1288,6 +1288,11 @@ impl RootSetup {
         self.boot.as_ref().map(require_boot_uuid).transpose()
     }
 
+    /// Get the boot mount spec, if a separate /boot partition exists.
+    pub(crate) fn boot_mount_spec(&self) -> Option<&MountSpec> {
+        self.boot.as_ref()
+    }
+
     // Drop any open file descriptors and return just the mount path and backing luks device, if any
     #[cfg(feature = "install-to-disk")]
     fn into_storage(self) -> (Utf8PathBuf, Option<String>) {


### PR DESCRIPTION
The composefs install path was not ensuring /boot gets mounted after reboot on systems with a separate /boot partition (e.g. to-existing-root installs). This broke `bootc status` and `bootc upgrade`.

Instead of writing to /etc/fstab (which conflicts with transient etc per https://github.com/bootc-dev/bootc/issues/1388), add a systemd.mount-extra kernel argument to the BLS boot entry. This tells systemd to mount the boot partition without requiring any /etc state.

Closes: https://github.com/bootc-dev/bootc/issues/2120
Assisted-by: Claude Code (Opus 4.6)