### PR TITLE
fix: add riscv64 to this_arch_root

### DIFF
--- a/crates/lib/src/discoverable_partition_specification.rs
+++ b/crates/lib/src/discoverable_partition_specification.rs
@@ -521,6 +521,8 @@ pub const fn this_arch_root() -> &'static str {
             ROOT_PPC64
         } else if #[cfg(all(target_arch = "powerpc64", target_endian = "little"))] {
             ROOT_PPC64_LE
+        } else if #[cfg(target_arch = "riscv64")] {
+            ROOT_RISCV64
         } else {
             compile_error!("Unsupported architecture")
         }


### PR DESCRIPTION
I'm trying to use bootc on a riscv64 machine, this_arch_root returns "Unsupported architecture" error
The root partition GUID is known: ROOT_RISCV64


