### PR TITLE
sd-boot: Don't generate random seed for generic images

### DIFF
--- a/crates/lib/src/bootloader.rs
+++ b/crates/lib/src/bootloader.rs
@@ -227,7 +227,7 @@ pub(crate) fn install_via_bootupd(
 pub(crate) fn install_systemd_boot(
     device: &bootc_blockdev::Device,
     _rootfs: &Utf8Path,
-    _configopts: &crate::install::InstallConfigOpts,
+    configopts: &crate::install::InstallConfigOpts,
     _deployment_path: Option<&str>,
     autoenroll: Option<SecurebootKeys>,
 ) -> Result<()> {
@@ -246,8 +246,15 @@ pub(crate) fn install_systemd_boot(
         .ok_or_else(|| anyhow::anyhow!("Failed to convert ESP mount path to UTF-8"))?;
 
     println!("Installing bootloader via systemd-boot");
+
+    let mut bootctl_args = vec!["install", "--esp-path", esp_path.as_str()];
+
+    if configopts.generic_image {
+        bootctl_args.extend(["--random-seed", "no"]);
+    }
+
     Command::new("bootctl")
-        .args(["install", "--esp-path", esp_path.as_str()])
+        .args(bootctl_args)
         .log_debug()
         .run_inherited_with_cmd_context()?;
 

--- a/hack/provision-derived.sh
+++ b/hack/provision-derived.sh
@@ -48,7 +48,7 @@ case "${ID}-${VERSION_ID}" in
 esac
 
 # Extra packages we install
-grep -Ev -e '^#' packages.txt | xargs dnf -y install
+grep -Ev -e '^#' packages.txt | xargs dnf install --allowerasing -y
 
 # Cloud bits
 cat <<KARGEOF >> /usr/lib/bootc/kargs.d/20-console.toml


### PR DESCRIPTION
For installations with `--generic-image` we don't really want a random-seed file to be generated in the ESP as these images would most likely be reused

Closes: https://github.com/bootc-dev/bootc/issues/2133