### PR TITLE
blockdev: handle ZFS dataset sources in list_dev_by_dir

### DIFF
--- a/crates/blockdev/src/blockdev.rs
+++ b/crates/blockdev/src/blockdev.rs
@@ -411,7 +411,7 @@ fn list_dev_for_zfs_dataset(dataset: &str) -> Result<Device> {
 pub fn list_dev_by_dir(dir: &Dir) -> Result<Device> {
     let fsinfo = bootc_mount::inspect_filesystem_of_dir(dir)?;
     let source = &fsinfo.source;
-    if fsinfo.fstype == "zfs" || (!source.starts_with('/') && source.contains('/')) {
+    if fsinfo.fstype == "zfs" || source.starts_with("ZFS=") {
         return list_dev_for_zfs_dataset(source);
     }
     list_dev(&Utf8PathBuf::from(source))

--- a/crates/blockdev/src/blockdev.rs
+++ b/crates/blockdev/src/blockdev.rs
@@ -382,10 +382,39 @@ pub fn list_dev(dev: &Utf8Path) -> Result<Device> {
         .ok_or_else(|| anyhow!("no device output from lsblk for {dev}"))
 }
 
+#[context("Finding block device for ZFS dataset {dataset}")]
+fn list_dev_for_zfs_dataset(dataset: &str) -> Result<Device> {
+    let dataset = dataset.strip_prefix("ZFS=").unwrap_or(dataset);
+    let pool = dataset
+        .split('/')
+        .next()
+        .ok_or_else(|| anyhow!("Invalid ZFS dataset: {dataset}"))?;
+
+    let output = Command::new("zpool")
+        .args(["list", "-H", "-v", "-P", pool])
+        .run_get_string()
+        .with_context(|| format!("Querying ZFS pool {pool}"))?;
+
+    for line in output.lines() {
+        if line.starts_with('\t') || line.starts_with(' ') {
+            let dev_path = line.trim_start().split('\t').next().unwrap_or("").trim();
+            if dev_path.starts_with('/') {
+                return list_dev(Utf8Path::new(dev_path));
+            }
+        }
+    }
+
+    anyhow::bail!("Could not find a block device backing ZFS pool {pool}")
+}
+
 /// List the device containing the filesystem mounted at the given directory.
 pub fn list_dev_by_dir(dir: &Dir) -> Result<Device> {
     let fsinfo = bootc_mount::inspect_filesystem_of_dir(dir)?;
-    list_dev(&Utf8PathBuf::from(&fsinfo.source))
+    let source = &fsinfo.source;
+    if fsinfo.fstype == "zfs" || (!source.starts_with('/') && source.contains('/')) {
+        return list_dev_for_zfs_dataset(source);
+    }
+    list_dev(&Utf8PathBuf::from(source))
 }
 
 pub struct LoopbackDevice {


### PR DESCRIPTION
ZFS filesystems report their mount source as a dataset name (e.g. `rpool/root`) rather than a block device path. Passing this to `lsblk` causes it to fail with `not a block device`, breaking `bootc status` and `bootc upgrade` on ZFS-rooted systems.

Add `list_dev_for_zfs_dataset()` which extracts the pool name and queries `zpool list -H -v -P <pool>` to find the underlying block device path, then delegates to `list_dev()` as normal.

Detect ZFS sources in `list_dev_by_dir()` via `fstype == "zfs"` or by a non-absolute path containing `/` (dataset name form).

## Testing

Tested on an Ubuntu 26.04 system installed to ZFS via `bootc install to-filesystem`. The installed system uses `rpool/root` as the rootfs.

- `bootc status` — previously failed with `lsblk: rpool/root: not a block device`, now returns full status output ✅
- `bootc upgrade --check` — previously failed at the same point, now successfully queries the registry ✅

Reproduced against v1.15.0 and verified fix against current main.

Fixes: #1240
Assisted-by: GitHub Copilot (claude-sonnet-4-6)