### PR TITLE
Use --nosignature when installing dev rpms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ ARG boot_type
 # Install our bootc package (only needed for the compute-composefs-digest command)
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=packages,src=/,target=/run/packages \
-    rpm -Uvh --oldpackage /run/packages/bootc-*.rpm
+    rpm -Uvh --oldpackage --nosignature /run/packages/bootc-*.rpm
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=secret,id=secureboot_key \
     --mount=type=secret,id=secureboot_cert \

--- a/contrib/packaging/install-rpm-and-setup
+++ b/contrib/packaging/install-rpm-and-setup
@@ -6,7 +6,7 @@ RPM_DIR="${1:-/tmp}"
 
 # Install the RPM package
 # Use rpm -Uvh with --oldpackage to allow replacing with dev version
-rpm -Uvh --oldpackage "${RPM_DIR}"/*.rpm
+rpm -Uvh --oldpackage --nosignature "${RPM_DIR}"/*.rpm
 # Note: we don't need to clean up the source directory since it's a bind mount
 
 # Regenerate initramfs if we have initramfs-setup


### PR DESCRIPTION
Newer fedora (rawhide at least) checks signatures by default and will
fail to install these since they're not signed

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
