### PR TITLE
install: Pass explicit filesystem type to mount after mkfs

### DIFF
--- a/crates/lib/src/install/baseline.rs
+++ b/crates/lib/src/install/baseline.rs
@@ -484,7 +484,8 @@ pub(crate) fn install_create_rootfs(
         }
     }
 
-    bootc_mount::mount(&rootdev_path, &physical_root_path)?;
+    let fstype = &root_filesystem.to_string();
+    bootc_mount::mount_typed(&rootdev_path, fstype, &physical_root_path)?;
     let target_rootfs = Dir::open_ambient_dir(&physical_root_path, cap_std::ambient_authority())?;
     crate::lsm::ensure_dir_labeled(&target_rootfs, "", Some("/".into()), 0o755.into(), sepolicy)?;
     let physical_root = Dir::open_ambient_dir(&physical_root_path, cap_std::ambient_authority())?;
@@ -492,7 +493,7 @@ pub(crate) fn install_create_rootfs(
     // Create the underlying mount point directory, which should be labeled
     crate::lsm::ensure_dir_labeled(&target_rootfs, "boot", None, 0o755.into(), sepolicy)?;
     if let Some(bootdev) = bootdev {
-        bootc_mount::mount(&bootdev.path(), &bootfs)?;
+        bootc_mount::mount_typed(&bootdev.path(), fstype, &bootfs)?;
     }
     // And we want to label the root mount of /boot
     crate::lsm::ensure_dir_labeled(&target_rootfs, "boot", None, 0o755.into(), sepolicy)?;

--- a/crates/mount/src/mount.rs
+++ b/crates/mount/src/mount.rs
@@ -145,6 +145,19 @@ pub fn mount(dev: &str, target: &Utf8Path) -> Result<()> {
         .run_inherited_with_cmd_context()
 }
 
+/// Mount a device with an explicit filesystem type.
+///
+/// This avoids relying on the `mount` utility's blkid auto-detection,
+/// which can fail in certain container environments (e.g. when the
+/// required filesystem kernel module is not yet loaded and the blkid
+/// probe doesn't work, causing mount to fall back to iterating
+/// `/etc/filesystems` and `/proc/filesystems`).
+pub fn mount_typed(dev: &str, fstype: &str, target: &Utf8Path) -> Result<()> {
+    Command::new("mount")
+        .args(["-t", fstype, dev, target.as_str()])
+        .run_inherited_with_cmd_context()
+}
+
 /// If the fsid of the passed path matches the fsid of the same path rooted
 /// at /proc/1/root, it is assumed that these are indeed the same mounted
 /// filesystem between container and host.


### PR DESCRIPTION
When mounting a freshly-created filesystem during install, pass
-t <fstype> to mount rather than relying on auto-detection.

util-linux 2.42 introduced an optimization (commit 8bdc2546d) where
libmount reads device properties from the udev database instead of
probing the device superblock with libblkid. When mkfs runs inside a
container, the udev database is stale for the filesystem type because
mkfs does not generate a kernel uevent — udev only re-probes devices
on kernel-generated events (such as partition table changes from
sfdisk), not on arbitrary block device writes. As a result, the udev
database has partition tags (PARTUUID, PARTLABEL) from sfdisk but
lacks ID_FS_TYPE. libmount's read_from_udev() returns success after
finding those partition tags, so the libblkid direct-probe fallback
is never called. Without a filesystem type, mount falls back to
iterating /etc/filesystems and /proc/filesystems, which fails for
filesystem modules (like xfs with CONFIG_XFS_FS=m) that are not yet
loaded.

Since bootc already knows the filesystem type (it just ran mkfs),
passing -t avoids the auto-detection path entirely.

Closes: #2148
Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
