### PR TITLE
tests: Skip BLI detection test when discoverable-partitions config is absent

### DIFF
--- a/tmt/tests/booted/readonly/052-test-bli-detection.nu
+++ b/tmt/tests/booted/readonly/052-test-bli-detection.nu
@@ -29,6 +29,16 @@ if not ($os_id == "fedora" and $version_id >= 43) {
     exit 0
 }
 
+# DPS root discovery only works when bootc install to-disk created the
+# partitions with DPS type GUIDs.  In Packit/gating CI the system was
+# installed via to-existing-root on pre-existing partitions, so skip.
+# BCVK_EXPORT=1 is set by xtask when running via bcvk (image-mode).
+if ($env.BCVK_EXPORT? | default "" | is-empty) {
+    print "# skip: not running in image-mode (BCVK_EXPORT not set)"
+    tap ok
+    exit 0
+}
+
 print $"Running on ($os_id) ($version_id), checking DPS root discovery"
 
 let cmdline = (open /proc/cmdline)


### PR DESCRIPTION
The 052-test-bli-detection test asserts that Fedora 43+ systems boot
without a root= kernel argument (using DPS auto-discovery instead).
However, this only works when the install was performed via
bootc install to-disk, which creates partitions with DPS type GUIDs.

In Packit/gating CI, the system is installed via
bootc install to-existing-root on a Testing Farm VM whose partitions
were not created with DPS type GUIDs. The test was unconditionally
failing in this environment.

Fix this by checking for the BCVK_EXPORT environment variable, which
is set by xtask when running tests via bcvk (image-mode). When not
in image-mode, the test skips since DPS root discovery cannot work
on partitions that lack the proper type GUIDs.

Fixes: https://github.com/bootc-dev/bootc/pull/2123
Assisted-by: OpenCode (Claude Opus 4.6)
Signed-off-by: Joseph Marrero Corchado <jmarrero@redhat.com>