### PR TITLE
Use `--replacepkgs` when installing local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ ARG boot_type
 # Install our bootc package (only needed for the compute-composefs-digest command)
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=packages,src=/,target=/run/packages \
-    rpm -Uvh --oldpackage --nosignature /run/packages/bootc-*.rpm
+    rpm -Uvh --oldpackage --replacepkgs --nosignature /run/packages/bootc-*.rpm
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=secret,id=secureboot_key \
     --mount=type=secret,id=secureboot_cert \

--- a/contrib/packaging/install-rpm-and-setup
+++ b/contrib/packaging/install-rpm-and-setup
@@ -4,9 +4,12 @@ set -xeuo pipefail
 
 RPM_DIR="${1:-/tmp}"
 
-# Install the RPM package
-# Use rpm -Uvh with --oldpackage to allow replacing with dev version
-rpm -Uvh --oldpackage --nosignature "${RPM_DIR}"/*.rpm
+# Install the RPM package Use rpm -Uvh with --oldpackage to allow
+# replacing with dev version, and --replacepkgs in case the NEVRA from
+# our local build already exists in the image which can happen if
+# there's no local modifications and it's already been pulled in from
+# the rhcontainerbot/bootc copr.
+rpm -Uvh --oldpackage --replacepkgs --nosignature "${RPM_DIR}"/*.rpm
 # Note: we don't need to clean up the source directory since it's a bind mount
 
 # Regenerate initramfs if we have initramfs-setup


### PR DESCRIPTION
Trying to run tests locally against rawhide was failing, because I
have no local modifications and the same package NEVRA already exists
in the rhcontainerbot/bootc copr repo which is installed previously.

Now if we have the same NEVRA via the local build we'll just
re-install the local version as effectively a no-op instead of
failing.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
