### PR TITLE
system-reinstall-bootc: SSH key handling via cloud-init detection

### DIFF
--- a/crates/system-reinstall-bootc/src/main.rs
+++ b/crates/system-reinstall-bootc/src/main.rs
@@ -73,20 +73,36 @@ fn run() -> Result<()> {
     let has_clean = podman::bootc_has_clean(&opts.image)?;
     spinner.finish_and_clear();
 
-    let ssh_key_file = tempfile::NamedTempFile::new()?;
-    let ssh_key_file_path = ssh_key_file
-        .path()
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("unable to create authorized_key temp file"))?;
+    let mut _ssh_key_tempfile = None;
+    let mut ssh_key_file_path = None;
 
-    tracing::trace!("ssh_key_file_path: {}", ssh_key_file_path);
+    if podman::image_has_cloud_init(&opts.image)? {
+        let host_root_keys = std::path::Path::new("/root/.ssh/authorized_keys");
+        if host_root_keys.exists() {
+            println!("Detected cloud-init and host keys. Inheriting keys automatically.");
+            ssh_key_file_path = Some(host_root_keys.to_string_lossy().into_owned());
+        } else {
+            println!("Detected cloud-init. Proceeding without host key inheritance.");
+        }
+    } else {
+        let file = tempfile::NamedTempFile::new()?;
+        let file_path = file
+            .path()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("unable to create authorized_key temp file"))?;
 
-    prompt::get_ssh_keys(ssh_key_file_path)?;
+        tracing::trace!("ssh_key_file_path: {}", file_path);
+
+        prompt::get_ssh_keys(file_path)?;
+
+        ssh_key_file_path = Some(file_path.to_string());
+        _ssh_key_tempfile = Some(file);
+    }
 
     prompt::mount_warning()?;
 
     let mut reinstall_podman_command =
-        podman::reinstall_command(&opts, ssh_key_file_path, has_clean)?;
+        podman::reinstall_command(&opts, ssh_key_file_path.as_deref(), has_clean)?;
 
     println!();
     println!("Going to run command:");

--- a/crates/system-reinstall-bootc/src/podman.rs
+++ b/crates/system-reinstall-bootc/src/podman.rs
@@ -1,7 +1,7 @@
-use crate::{ReinstallOpts, prompt};
+use crate::{prompt, ReinstallOpts};
 
 use super::ROOT_KEY_MOUNT_POINT;
-use anyhow::{Context, Result, ensure};
+use anyhow::{ensure, Context, Result};
 use bootc_utils::CommandRunExt;
 use fn_error_context::context;
 use std::process::Command;
@@ -24,10 +24,29 @@ pub(crate) fn bootc_has_clean(image: &str) -> Result<bool> {
     Ok(stdout_str.contains("--cleanup"))
 }
 
+#[context("image_has_cloud_init")]
+pub(crate) fn image_has_cloud_init(image: &str) -> Result<bool> {
+    let result = Command::new("podman")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            "sh",
+            image,
+            "-c",
+            "command -v cloud-init",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+
+    Ok(result.success())
+}
+
 #[context("reinstall_command")]
 pub(crate) fn reinstall_command(
     opts: &ReinstallOpts,
-    ssh_key_file: &str,
+    ssh_key_file: Option<&str>,
     has_clean: bool,
 ) -> Result<Command> {
     let mut podman_command_and_args = [
@@ -88,11 +107,13 @@ pub(crate) fn reinstall_command(
         bootc_command_and_args.push("--cleanup".to_string());
     }
 
-    podman_command_and_args.push("-v".to_string());
-    podman_command_and_args.push(format!("{ssh_key_file}:{ROOT_KEY_MOUNT_POINT}"));
+    if let Some(ssh_key_file) = ssh_key_file {
+        podman_command_and_args.push("-v".to_string());
+        podman_command_and_args.push(format!("{ssh_key_file}:{ROOT_KEY_MOUNT_POINT}"));
 
-    bootc_command_and_args.push("--root-ssh-authorized-keys".to_string());
-    bootc_command_and_args.push(ROOT_KEY_MOUNT_POINT.to_string());
+        bootc_command_and_args.push("--root-ssh-authorized-keys".to_string());
+        bootc_command_and_args.push(ROOT_KEY_MOUNT_POINT.to_string());
+    }
 
     let all_args = [
         podman_command_and_args,


### PR DESCRIPTION
If cloud-init is detected in the target image:
1. Check the host for existing root SSH keys at /root/.ssh/authorized_keys.
2. If host keys exist, automatically configure inheritance via /target/root/.ssh/authorized_keys.
3. If no host keys exist, proceed without manual interaction, trusting cloud-init in the new system to handle key provisioning.

If cloud-init is not detected, maintain the existinginteractive behavior to prevent user lock-out.

Ref: #1300