### PR TITLE
install: Skip discoverable-partitions config for FCOS builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,7 @@ RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp
 FROM base as base-penultimate
 ARG variant
 ARG bootloader
+ARG SKIP_CONFIGS
 # Switch to a signed systemd-boot, if configured
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=packaging,src=/,target=/run/packaging \
@@ -183,7 +184,7 @@ RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=packaging,src=/,target=/run/packaging \
     --mount=type=bind,from=packages,src=/,target=/run/packages \
-    /run/packaging/install-rpm-and-setup /run/packages
+    SKIP_CONFIGS="${SKIP_CONFIGS}" /run/packaging/install-rpm-and-setup /run/packages
 # Inject some other configuration
 COPY --from=packaging /usr-extras/ /usr/
 # Clean up package manager caches

--- a/contrib/packaging/install-rpm-and-setup
+++ b/contrib/packaging/install-rpm-and-setup
@@ -24,12 +24,16 @@ touch /usr/lib/.bootc-dev-stamp
 # Fedora 43+ ships a GRUB with the BLI module, so enable DPS
 # auto-discovery for root.  This must run after our RPM is installed
 # since older bootc doesn't recognize the discoverable-partitions key.
-. /usr/lib/os-release
-if [ "${ID}" = "fedora" ] && [ "${VERSION_ID}" -ge 43 ] 2>/dev/null; then
-  cat > /usr/lib/bootc/install/20-discoverable-partitions.toml <<'EOF'
+# Skip this when SKIP_CONFIGS is set (e.g. for CoreOS testing, where the
+# target system uses its own partitioning scheme without DPS type GUIDs).
+if [ -z "${SKIP_CONFIGS:-}" ]; then
+  . /usr/lib/os-release
+  if [ "${ID}" = "fedora" ] && [ "${VERSION_ID}" -ge 43 ] 2>/dev/null; then
+    cat > /usr/lib/bootc/install/20-discoverable-partitions.toml <<'EOF'
 [install]
 discoverable-partitions = true
 EOF
+  fi
 fi
 
 # Workaround for https://github.com/bootc-dev/bootc/issues/1546


### PR DESCRIPTION
Currently Fedora CoreOS derivatives don't yet work with systemd-gpt-auto-generator, see https://github.com/coreos/fedora-coreos-tracker/issues/2137

It was briefly in an image which let our CI change to depend on it pass.

Fix this by passing the existing `SKIP_CONFIGS` variable into the coreos image build.

Closes: https://github.com/bootc-dev/bootc/issues/2160
Assisted-by: OpenCode (Claude Opus 4)