### PR TITLE
ci: Enable merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch: {}
 
 env:
@@ -251,7 +252,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: "tmt-log-PR-${{ github.event.number }}-\
+          name: "tmt-log-\
             ${{ matrix.test_os }}-\
             ${{ matrix.variant }}-\
             ${{ matrix.bootloader }}-\
@@ -304,7 +305,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: "tmt-log-PR-${{ github.event.number }}-${{ matrix.test_os }}-${{ matrix.variant }}-upgrade-${{ env.ARCH }}"
+          name: "tmt-log-${{ matrix.test_os }}-${{ matrix.variant }}-upgrade-${{ env.ARCH }}"
           path: /var/tmp/tmt
 
   # Test bootc install on Fedora CoreOS (separate job to avoid disk space issues
@@ -346,7 +347,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: tmt-log-PR-${{ github.event.number }}-fedora-43-coreos-${{ env.ARCH }}
+          name: tmt-log-fedora-43-coreos-${{ env.ARCH }}
           path: /var/tmp/tmt
 
   # Test the container export -> Anaconda liveimg install path.


### PR DESCRIPTION
Add merge_group to the CI workflow triggers so that GitHub merge queues can be used. This is a prerequisite for enabling merge queues on the repository.

Also drop the PR number from artifact names — artifacts are already scoped to a workflow run, so the matrix parameters alone provide sufficient uniqueness.

Ref: https://github.com/bootc-dev/infra/issues/143
Assisted-by: OpenCode (Claude Opus 4)