### PR TITLE
Use `--replacepkgs` when installing local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -246,7 +246,7 @@ ARG boot_type
 # Install our bootc package (only needed for the compute-composefs-digest command)
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=packages,src=/,target=/run/packages \
-    rpm -Uvh --oldpackage --nosignature /run/packages/bootc-*.rpm
+    rpm -Uvh --oldpackage --replacepkgs --nosignature /run/packages/bootc-*.rpm
 RUN --network=none --mount=type=tmpfs,target=/run --mount=type=tmpfs,target=/tmp \
     --mount=type=secret,id=secureboot_key \
     --mount=type=secret,id=secureboot_cert \


### PR DESCRIPTION
Trying to run tests locally against rawhide was failing, because I
have no local modifications and the same package NEVRA already exists
in the rhcontainerbot/bootc copr repo which is installed previously.

Now if we have the same NEVRA via the local build we'll just
re-install the local version as effectively a no-op instead of
failing.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
