### PR TITLE
Add meetings directory with instructions to find meetings and notes

### DIFF
--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,0 +1,47 @@
+# bootc Community Meetings
+
+The bootc project holds weekly community meetings to discuss development, features, bugs, and community topics.
+
+## Meeting Schedule
+
+**When:** Every Friday at 15:30 UTC  
+**Where:** [CNCF Zoom](https://zoom-lfx.platform.linuxfoundation.org/)  
+**Calendar:** Meetings are listed on the [CNCF public calendar](https://www.cncf.io/calendar/) - search for "bootc"
+
+## Meeting Notes
+
+Meeting notes are captured and shared in two ways:
+
+### 1. **Collaborative Notes (HackMD)**
+Live collaborative notes during meetings are maintained at:  
+[https://hackmd.io/V27jrOh4Sou-ZLcvrhHzJA](https://hackmd.io/V27jrOh4Sou-ZLcvrhHzJA)
+
+Anyone can view and contribute to the notes during the meeting.
+
+### 2. **AI-Generated Meeting Summaries (Zoom)**
+After each meeting, Zoom automatically generates and publishes meeting summaries with:
+- Transcripts
+- Action items
+- Key discussion points
+
+**Access:** 
+- Meeting attendees receive summaries automatically via email
+- Non-attendees can access summaries through the calendar invite after the meeting concludes ([CNCF public calendar](https://www.cncf.io/calendar/) - search for "bootc")
+
+## How to Participate
+
+- **Register:** In the CNCF bootc project calendar, register for the meeting. You should then get an invite to attend, or you can use the Zoom link available in the event on the calendar and join without registration
+- **Propose agenda items:** Add topics to the HackMD document before the meeting
+- **Review past discussions:** Check the HackMD or Zoom summaries for historical notes
+
+## Meeting Guidelines
+
+- Meetings are open to all community members
+- Please be respectful and follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- Keep discussions focused on bootc-related topics
+
+## Questions?
+
+For questions about meetings or to propose agenda items, reach out via:
+- [#bootc-dev on CNCF Slack](https://cloud-native.slack.com/archives/C08SKSQKG1L)
+


### PR DESCRIPTION
Documents where to find the community meeting, notes, and how to access them. Includes links to HackMD collaborative notes and instructions to access the zoom generated summaries.