### PR TITLE
install: don't fsfreeze VFAT

### DIFF
--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1421,11 +1421,19 @@ pub(crate) fn finalize_filesystem(
         .args(["-o", "remount,ro", path.as_str()])
         .run()?;
     // Finally, freezing (and thawing) the filesystem will flush the journal, which means the next boot is clean.
-    for a in ["-f", "-u"] {
-        Command::new("fsfreeze")
-            .cwd_dir(root.try_clone()?)
-            .args([a, path.as_str()])
-            .run_capture_stderr()?;
+    // VFAT has no journal and does not support fsfreeze. Might need to be expanded in the future
+    // to also *not* fsfreeze other filesystems.
+    let fsdir = root.open_dir(path.as_str())?;
+    let st = rustix::fs::fstatfs(fsdir.as_fd())?;
+    if st.f_type == libc::MSDOS_SUPER_MAGIC {
+        tracing::debug!("Filesystem {fsname} is VFAT, skipping fsfreeze");
+    } else {
+        for a in ["-f", "-u"] {
+            Command::new("fsfreeze")
+                .cwd_dir(root.try_clone()?)
+                .args([a, path.as_str()])
+                .run_capture_stderr()?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
When finalize_filesystems is called there are no checks that the filesystem actually supports FIFREEZE/FITHAW.

I ran into this when `bootc install to-filesystem` tried to fsfreeze my ESP; which was mounted at `/boot` as the BLS spec dictates.

Let's at least naively skip fsfreeze on VFAT (probably the most common case for an unsupported filesystem, and ext(2|3|4) is harder to tell apart.