### PR TITLE
Remove bootupd copr install

### DIFF
--- a/hack/provision-fetch.sh
+++ b/hack/provision-fetch.sh
@@ -54,57 +54,6 @@ if test $cloudinit = 1; then
   dnf -y install cloud-init
 fi
 
-# Temporary: update bootupd from @CoreOS/continuous copr until
-# base images include a version supporting --filesystem
-case $ID in
-    fedora) copr_distro="fedora" ;;
-    *) copr_distro="centos-stream" ;;
-esac
-# Update bootc from rhcontainerbot copr; the new bootupd
-# requires a newer bootc than what ships in some base images.
-cat >/etc/yum.repos.d/rhcontainerbot-bootc.repo <<REPOEOF
-[copr:copr.fedorainfracloud.org:rhcontainerbot:bootc]
-name=Copr repo for bootc owned by rhcontainerbot
-baseurl=https://download.copr.fedorainfracloud.org/results/rhcontainerbot/bootc/${copr_distro}-\$releasever-\$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/rhcontainerbot/bootc/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-REPOEOF
-dnf -y update bootc
-rm -f /etc/yum.repos.d/rhcontainerbot-bootc.repo
-cat >/etc/yum.repos.d/coreos-continuous.repo <<REPOEOF
-[copr:copr.fedorainfracloud.org:group_CoreOS:continuous]
-name=Copr repo for continuous owned by @CoreOS
-baseurl=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/${copr_distro}-\$releasever-\$basearch/
-type=rpm-md
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-REPOEOF
-
-# This unfortunately has "older" versions with higher NEVRA:
-#
-# # dnf --disablerepo=* --enablerepo=copr:copr.fedorainfracloud.org:group_CoreOS:continuous repoquery bootupd 2> /dev/null
-# bootupd-0:0.2.32.45.gb483a63-1.fc45.x86_64
-# bootupd-0:202501200321.0.2.25.65.ge296f82-1.fc42.src
-# bootupd-0:202501200321.0.2.25.65.ge296f82-1.fc42.x86_64
-# bootupd-0:202501210627.0.2.25.67.gefe41b6-1.fc42.src
-#
-# So we need to be more selective, but also be dynamic to grab newer
-# versions
-#
-# The subscription-manager plugin needs to be disabled because it
-# likes to write warnings to stdout which corrupts the NEVRA output
-# we're going for here...
-bootupd_nevra=$(dnf --disableplugin=subscription-manager --disablerepo=* --enablerepo=copr:copr.fedorainfracloud.org:group_CoreOS:continuous repoquery --latest-limit 1 --arch "$(uname -m)" "bootupd-0.2.*")
-dnf -y install ${bootupd_nevra}
-rm -f /etc/yum.repos.d/coreos-continuous.repo
-
 # Temporary: upgrade ostree to 2026.1 for bootconfig-extra support
 # (required by loader-entries source tracking)
 # xref https://github.com/ostreedev/ostree/pull/3570


### PR DESCRIPTION
Looks like the updated package has disappeared from the copr in
conjunction with it landing in the base images, so I think we can
remove all of this now.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
