### PR TITLE
deps: Bump bcvk-qemu to e953294

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bcvk-qemu"
 version = "0.1.0"
-source = "git+https://github.com/bootc-dev/bcvk?rev=eac2fc357d059ba3cfcf5cd7a5fc00e6e5e70a7c#eac2fc357d059ba3cfcf5cd7a5fc00e6e5e70a7c"
+source = "git+https://github.com/bootc-dev/bcvk?rev=e953294441c49bc6cd8a25fb5e6b5d7a71eaa143#e953294441c49bc6cd8a25fb5e6b5d7a71eaa143"
 dependencies = [
  "camino",
  "cap-std-ext 5.1.2",

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -30,7 +30,7 @@ bootc-kernel-cmdline = { path = "../kernel_cmdline", version = "0.0.0" }
 # This is a git dependency — not published to crates.io.
 # When updating, also check the bcvk-qemu Cargo.toml for its own
 # dependency versions (cap-std-ext, etc.) to avoid conflicts.
-bcvk-qemu = { git = "https://github.com/bootc-dev/bcvk", rev = "eac2fc357d059ba3cfcf5cd7a5fc00e6e5e70a7c" }
+bcvk-qemu = { git = "https://github.com/bootc-dev/bcvk", rev = "e953294441c49bc6cd8a25fb5e6b5d7a71eaa143" }
 data-encoding = "2.9"
 indicatif = { workspace = true }
 libtest-mimic = "0.8.0"

--- a/crates/tests-integration/src/anaconda.rs
+++ b/crates/tests-integration/src/anaconda.rs
@@ -445,6 +445,7 @@ After=anaconda-program-log.service"#;
         debug: false,
         readonly: true,
         log_file: None,
+        virtiofsd_binary: None,
     };
 
     // Build QemuConfig using bcvk-qemu


### PR DESCRIPTION
Update bcvk-qemu to the latest version. The VirtiofsConfig struct
gained a virtiofsd_binary field in
https://github.com/bootc-dev/bcvk/pull/266 (f661aad), so update
the struct literal in anaconda.rs accordingly.

Assisted-by: OpenCode (Claude claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
