### PR TITLE
docs: Replace bootc-dev.github.io with bootc.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ can be upgraded in place seamlessly across any future changes.
 
 ## Documentation
 
-See the [project documentation](https://bootc-dev.github.io/bootc/).
+See the [project documentation](https://bootc.dev/bootc/).
 
 ## Versioning
 

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -8,9 +8,9 @@
 //! to provide a fully "container native" tool for using
 //! bootable container images.
 //!
-//! For user-facing documentation, see <https://bootc-dev.github.io/bootc/>.
+//! For user-facing documentation, see <https://bootc.dev/bootc/>.
 //! For architecture and internals documentation, see the
-//! [Internals](https://bootc-dev.github.io/bootc/internals.html) section.
+//! [Internals](https://bootc.dev/bootc/internals.html) section.
 //!
 //! # Crate Overview
 //!

--- a/crates/lib/src/lints.rs
+++ b/crates/lib/src/lints.rs
@@ -625,7 +625,7 @@ static LINT_BASEIMAGE_ROOT: Lint = Lint::new_fatal(
     indoc! { r#"
 Check that expected files are present in the root of the filesystem; such
 as /sysroot and a composefs configuration for ostree. More in
-<https://bootc-dev.github.io/bootc/bootc-images.html#standard-image-content>.
+<https://bootc.dev/bootc/bootc-images.html#standard-image-content>.
 "#},
     check_baseimage_root,
 );
@@ -736,7 +736,7 @@ image may not be visible.
 Using systemd-sysusers to allocate users and groups will ensure that these are allocated
 on system startup alongside other users.
 
-More on this topic in <https://bootc-dev.github.io/bootc/building/users-and-groups.html>
+More on this topic in <https://bootc.dev/bootc/building/users-and-groups.html>
 "# },
     check_sysusers,
 );

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: containers/bootc
 description: bootc documentation
 baseurl: "/bootc"
-url: "https://bootc-dev.github.io"
+url: "https://bootc.dev"
 # Comment above and use below for local development
 # url: "http://localhost:4000"
 permalink: /:title/


### PR DESCRIPTION
Standardize all documentation URLs to use the new bootc.dev domain.

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
