### PR TITLE
xtask: Use insecure firmware for all non-sealed VM tests

### DIFF
--- a/crates/xtask/src/bcvk.rs
+++ b/crates/xtask/src/bcvk.rs
@@ -110,10 +110,14 @@ impl BcvkInstallOpts {
                      Run 'just generate-secureboot-keys' to generate them."
                 );
             }
-        } else if matches!(self.bootloader, Some(Bootloader::Systemd)) {
-            Ok(vec!["--firmware=uefi-insecure".into()])
         } else {
-            Ok(Vec::new())
+            // Use insecure firmware for all non-sealed images.  The stock
+            // OVMF Secure Boot key database does not include the distro
+            // signing keys needed to verify shim/grub, so Secure Boot
+            // verification fails at the firmware level with
+            // "Security Violation".  Sealed images work because they enroll
+            // custom test keys and use a test-signed systemd-boot.
+            Ok(vec!["--firmware=uefi-insecure".into()])
         }
     }
 }


### PR DESCRIPTION
The stock OVMF Secure Boot key database (shipped with the Ubuntu runner's
edk2/ovmf package) does not include the distro signing keys needed to
verify the shim/grub chain for CentOS Stream or Fedora.  Previously,
only systemd-boot tests explicitly requested --firmware=uefi-insecure
while grub tests inherited bcvk's default of uefi-secure, causing UEFI
to reject the boot with 'Security Violation'.

This worked by coincidence until the CentOS Stream 10 compose re-signed
grub2 (2.12-47) with a different certificate (Signing 802 / CA 8 instead
of Signing 202 / CA 2), which changed the Authenticode signature and
broke whatever fragile verification path was succeeding before.

Fix by using --firmware=uefi-insecure for all non-sealed images.  Sealed
images continue to use uefi-secure with explicitly enrolled test keys.

Signed-off-by: Joseph Marrero Corchado <jmarrero@redhat.com>
Assisted-by: OpenCode (Claude claude-opus-4-6)