### PR TITLE
switch: fix --apply not rebooting when already staged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ accepted!
 - A development environment (toolbox or a host) with a Rust and C compiler, etc.
   While this isn't specific to bootc, you will find the experience of working on Rust
   is greatly aided with use of e.g. [rust-analyzer](https://github.com/rust-lang/rust-analyzer/).
-- Install [bcvk](https://github.com/bootc-dev/bcvk).
+- Install [bcvk](https://github.com/bootc-dev/bcvk). For running TMT
+  integration tests, also install `tmt` and `libvirt`
+  (e.g. `dnf install bcvk tmt libvirt`).
 
 ## Ensure you're familiar with a bootc system
 

--- a/crates/lib/src/bootc_composefs/status.rs
+++ b/crates/lib/src/bootc_composefs/status.rs
@@ -890,7 +890,6 @@ async fn composefs_deployment_status_from(
         };
 
         if verity_digest == booted_composefs_digest.as_ref() {
-            host.spec.image = boot_entry.image.as_ref().map(|x| x.image.clone());
             host.status.booted = Some(boot_entry);
             continue;
         }
@@ -907,6 +906,15 @@ async fn composefs_deployment_status_from(
 
         extra_deployment_boot_entries.push(boot_entry);
     }
+
+    // see similar logic in the ostree-version of this
+    host.spec.image = host
+        .status
+        .staged
+        .as_ref()
+        .or(host.status.booted.as_ref())
+        .and_then(|entry| entry.image.as_ref())
+        .map(|img| img.image.clone());
 
     // Shouldn't really happen, but for sanity nonetheless
     let Some(boot_type) = boot_type else {

--- a/crates/lib/src/bootc_composefs/switch.rs
+++ b/crates/lib/src/bootc_composefs/switch.rs
@@ -31,6 +31,9 @@ pub(crate) async fn switch_composefs(
 
     if new_spec == host.spec {
         println!("Image specification is unchanged.");
+        if opts.apply && host.status.staged.is_some() {
+            crate::reboot::reboot()?;
+        }
         return Ok(());
     }
 

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1398,6 +1398,9 @@ async fn switch_ostree(
 
     if new_spec == host.spec {
         println!("Image specification is unchanged.");
+        if opts.apply && host.status.staged.is_some() {
+            crate::reboot::reboot()?;
+        }
         return Ok(());
     }
 

--- a/tmt/README.md
+++ b/tmt/README.md
@@ -1,11 +1,6 @@
-# Run integration test locally
+# TMT integration tests
 
-In the bootc CI, integration tests are executed via Packit on the Testing Farm. In addition, the integration tests can also be run locally on a developer's machine, which is especially valuable for debugging purposes.
+In the bootc CI, integration tests are executed via Packit on the Testing Farm.
 
-To run integration tests locally, you need to [install tmt](https://tmt.readthedocs.io/en/stable/guide.html#the-first-steps) and `provision-virtual` plugin in this case. Be ready with `dnf install -y tmt+provision-virtual`. Then, use `tmt run -vvvvv plans -n integration` command to run the all integration tests.
-
-To run integration tests on different distros, just change `image: fedora-rawhide` in https://github.com/bootc-dev/bootc/blob/9d15eedea0d54a4dbc15d267dbdb055817336254/tmt/plans/integration.fmf#L6.
-
-The available images value can be found from https://tmt.readthedocs.io/en/stable/plugins/provision.html#images.
-
-Enjoy integration test local running!
+See [CONTRIBUTING.md](../CONTRIBUTING.md#running-tmt-integration-tests) for
+instructions on running them locally.

--- a/tmt/tests/booted/test-image-upgrade-reboot.nu
+++ b/tmt/tests/booted/test-image-upgrade-reboot.nu
@@ -8,7 +8,8 @@
 # This test does:
 # bootc image copy-to-storage
 # podman build <from that image>
-# bootc switch <into that image> --apply
+# bootc switch <into that image> (stage only)
+# bootc switch --apply <same image> (spec unchanged, must still reboot)
 # Verify we boot into the new image
 #
 # For composefs builds, it additionally verifies that composefs is
@@ -65,10 +66,13 @@ def initial_build [] {
         $st.status.booted.composefs.verity | save /var/original-verity
     }
 
-    # Now, switch into the new image
-    print $"Applying ($imgsrc)"
+    # Now, switch into the new image. First stage it, then run switch --apply for
+    # the same target. This exercises the case where --apply must still reboot for
+    # staged deployments.
+    print $"Staging ($imgsrc)"
     bootc switch --transport containers-storage ($imgsrc)
-    tmt-reboot
+    print "Re-running with --apply (spec unchanged, should still reboot)"
+    tmt-reboot -c $"bootc switch --apply --transport containers-storage ($imgsrc)"
 }
 
 # Check we have the updated image


### PR DESCRIPTION
When `bootc switch --apply` is called targeting an image that is already
staged, the spec comparison short-circuits with 'Image specification is
unchanged' and returns early without rebooting. This is the same class
of bug that was fixed for `bootc upgrade --apply` in commit 0067a47c.

Fix both the ostree and composefs switch paths.

Full AI use (reproduced bug, patched bootc, verified bugfix). I verified
the verification and the patch.