### PR TITLE
initramfs: tolerate pre-existing /run/systemd/volatile-root symlink

### DIFF
--- a/crates/initramfs/src/lib.rs
+++ b/crates/initramfs/src/lib.rs
@@ -419,8 +419,13 @@ pub fn gpt_workaround() -> Result<()> {
         major(rootdev.st_rdev),
         minor(rootdev.st_rdev)
     );
-    symlink(target, "/run/systemd/volatile-root")?;
-    Ok(())
+    // Handle the case where the symlink was already created before bootc
+    // runs, e.g. by ostree-prepare-root
+    // (https://github.com/ostreedev/ostree/pull/3608).
+    match symlink(target, "/run/systemd/volatile-root") {
+        Ok(()) | Err(Errno::EXIST) => Ok(()),
+        Err(err) => Err(err).context("Creating /run/systemd/volatile-root"),
+    }
 }
 
 /// Sets up /sysroot for switch-root


### PR DESCRIPTION
ostree-prepare-root is growing the same gpt-auto workaround for composefs roots (creating the /run/systemd/volatile-root symlink so systemd's blockdev_get_root() can resolve the backing device, see https://github.com/systemd/systemd/issues/35017), proposed in https://github.com/ostreedev/ostree/pull/3608. It runs before bootc-root-setup.service, so once that lands the symlink already exists by the time gpt_workaround() runs, and the unconditional symlink() call makes the service fail.

Both creators point the symlink at the /dev/block/MAJ:MIN alias of the same physical root device, so simply ignore EEXIST, matching how ensure_dir() handles already-existing directories.