### PR TITLE
tests: Skip test-loader-entries-source for ostree v2026.2

### DIFF
--- a/tmt/tests/booted/test-loader-entries-source.nu
+++ b/tmt/tests/booted/test-loader-entries-source.nu
@@ -25,6 +25,13 @@
 use std assert
 use tap.nu
 
+let is_bad_version = ostree --version | lines | any {|l| $l | str contains "2026.2" }
+
+if $is_bad_version {
+    print "Found Ostree v2026.2, skipping test"
+    exit 0
+}
+
 def parse_cmdline [] {
     open /proc/cmdline | str trim | split row " "
 }


### PR DESCRIPTION
This test ends up failing for systems with ostree v2026.2. Disable it until we have a fix