### PR TITLE
ci: A few improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           test ${{ matrix.test_os }} = "${used_vid}"
 
       - name: Unit and container integration tests
-        run: just test-container
+        run: BOOTC_SKIP_PACKAGE=1 just test-container
 
       - name: Validate composefs digest (UKI only)
         if: matrix.boot_type == 'uki'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,9 @@ jobs:
         if: matrix.boot_type == 'uki'
         run: just validate-composefs-digest
 
+      - name: Reclaim disk space before TMT
+        run: podman builder prune -af
+
       - name: Run TMT integration tests
         run: |
           if [[ "${{ matrix.variant }}" = composefs ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Disable incremental compilation in CI; it wastes disk in the container
+  # build cache (--mount=type=cache,target=/src/target) and doesn't help
+  # one-shot builds. Wired into container builds via Justfile --build-arg.
+  CARGO_INCREMENTAL: "0"
   # Something seems to be setting this in the default GHA runners, which breaks bcvk
   # as the default runner user doesn't have access
   LIBVIRT_DEFAULT_URI: "qemu:///session"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ COPY contrib/packaging /
 FROM $base as buildroot
 # Flip this off to disable initramfs code
 ARG initramfs=1
+# CI passes --build-arg=CARGO_INCREMENTAL=0 to save disk in the build cache.
+# When unset (local dev), cargo uses its profile defaults.
+ARG CARGO_INCREMENTAL
+ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL}
 # This installs our buildroot, and we want to cache it independently of the rest.
 # Basically we don't want changing a .rs file to blow out the cache of packages.
 # Use tmpfs for /run and /tmp with bind mounts inside to avoid leaking mount stubs into the image

--- a/Justfile
+++ b/Justfile
@@ -65,7 +65,10 @@ fedora-coreos := "quay.io/fedora/fedora-coreos:testing-devel"
 generic_buildargs := ""
 _extra_src_args := if extra_src != "" { "-v " + extra_src + ":/run/extra-src:ro --security-opt=label=disable" } else { "" }
 # filesystem arg: required for bootc container ukify to allow missing fsverity
+# CARGO_INCREMENTAL is passed through as-is (CI sets it to 0); empty is a no-op,
+# leaving cargo's own profile defaults in effect in the Dockerfile.
 base_buildargs := generic_buildargs + " " + _extra_src_args \
+                  + " --build-arg=CARGO_INCREMENTAL=" + env("CARGO_INCREMENTAL", "") \
                   + " --build-arg=base=" + base \
                   + " --build-arg=variant=" + variant \
                   + " --build-arg=bootloader=" + bootloader \


### PR DESCRIPTION
Mainly reducing disk usage to hopefully reduce flakes. A *very* surprising discovery is that some GHA runners have 70G disks, others have 140G, and there's apparently no way to steer them. This explains a good bit of the disk usage flakes.