### PR TITLE
ci: Run unit tests once per OS instead of once per test-integration leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,13 @@ jobs:
           path: target/packages/*.rpm
           retention-days: 1
 
+      # Unit tests don't depend on the variant/filesystem/bootloader/boot_type/seal_state
+      # axes used by the test-integration matrix below, so we run them once per OS here
+      # (reusing the BuildKit cache already warmed by `just check-buildsys` above) instead
+      # of once per matrix leg.
+      - name: Unit tests
+        run: just unit-tests
+
   # Build bootc from source into a container image FROM each specified base `test_os`
   # running unit and integration tests (using TMT, leveraging the support for nested virtualization
   # in the GHA runners)
@@ -310,8 +317,8 @@ jobs:
           used_vid=$(podman run --rm localhost/bootc bash -c '. /usr/lib/os-release && echo ${ID}-${VERSION_ID}')
           test ${{ matrix.test_os }} = "${used_vid}"
 
-      - name: Unit and container integration tests
-        run: BOOTC_SKIP_PACKAGE=1 just test-container
+      - name: Container integration tests
+        run: BOOTC_SKIP_PACKAGE=1 just test-container-integration
 
       - name: Validate composefs digest (UKI only)
         if: matrix.boot_type == 'uki'

--- a/Justfile
+++ b/Justfile
@@ -188,11 +188,24 @@ test-tmt *ARGS: build
     @just _build-upgrade-image
     @just test-tmt-nobuild {{ARGS}}
 
+# Split out from `test-container` because, unlike the container integration tests,
+# unit tests don't depend on variant/filesystem/bootloader/boot_type/seal_state, so
+# CI runs this once per OS (in the `package` job) instead of once per test-integration
+# matrix leg.
+# Run the unit test suite in a container (needs e.g. ostree/composefs shared libs)
+[group('core')]
+unit-tests: build-units
+    podman run --rm --read-only localhost/bootc-units /usr/bin/bootc-units
+
+# Used by CI's test-integration matrix, where unit tests already ran once per OS.
+# Run the container integration tests only (no unit tests)
+[group('core')]
+test-container-integration: build
+    podman run --rm --env=BOOTC_variant={{variant}} --env=BOOTC_base={{base}} --env=BOOTC_boot_type={{boot_type}} --mount=type=image,source={{base_img}},target=/run/target {{base_img}} bootc-integration-tests container
+
 # Run containerized unit and integration tests
 [group('core')]
-test-container: build build-units
-    podman run --rm --read-only localhost/bootc-units /usr/bin/bootc-units
-    podman run --rm --env=BOOTC_variant={{variant}} --env=BOOTC_base={{base}} --env=BOOTC_boot_type={{boot_type}} --mount=type=image,source={{base_img}},target=/run/target {{base_img}} bootc-integration-tests container
+test-container: unit-tests test-container-integration
 
 [group('core')]
 test-composefs bootloader filesystem boot_type seal_state *ARGS:


### PR DESCRIPTION
I noticed we were spending a lot of time in each integration test job building Rust code for the unit tests. Since none of that varies per matrix, move that into the package job.

Assisted-by: https://github.com/cgwalters/cgwalters#llms