### PR TITLE
docs: Add top-level LICENSE file for OpenSSF badge compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+This project is dual-licensed under the MIT License and the Apache License,
+Version 2.0. You may choose either license at your option.
+
+See LICENSE-MIT for the MIT License.
+See LICENSE-APACHE for the Apache License, Version 2.0.
+
+SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
- Add a top-level `LICENSE` file that references `LICENSE-MIT` and `LICENSE-APACHE`
- The OpenSSF Best Practices badge automation requires a file literally named `LICENSE` at the repo root; it does not recognize the `LICENSE-MIT` / `LICENSE-APACHE` naming convention
- This addresses the `license_location` criterion on the [OpenSSF badge](https://www.bestpractices.dev/projects/10113)