### PR TITLE
install/aleph: add `.aleph-version.json` symlink

### DIFF
--- a/crates/lib/src/install/aleph.rs
+++ b/crates/lib/src/install/aleph.rs
@@ -8,9 +8,15 @@ use ostree_ext::{container as ostree_container, oci_spec};
 use serde::Serialize;
 
 use super::SELinuxFinalState;
+use crate::utils::symlink_idempotent;
 
 /// Path to initially deployed version information
 pub(crate) const BOOTC_ALEPH_PATH: &str = ".bootc-aleph.json";
+/// Compatibility symlink target.
+/// Legacy from coreOS and osbuild where the
+/// aleph data is accessible at this expected path.
+/// See <https://github.com/coreos/fedora-coreos-tracker/issues/2187>
+const ALEPH_SYMLINK: &str = ".aleph-version.json";
 
 /// The "aleph" version information is injected into /root/.bootc-aleph.json
 /// and contains the image ID that was initially used to install.  This can
@@ -80,11 +86,16 @@ impl InstallAleph {
         Ok(r)
     }
 
-    /// Serialize to a file in the target root.
+    /// Serialize to a file in the target root, and create a compatibility symlink.
     pub(crate) fn write_to(&self, root: &Dir) -> Result<()> {
         root.atomic_replace_with(BOOTC_ALEPH_PATH, |f| {
             anyhow::Ok(self.to_canon_json_writer(f)?)
         })
-        .context("Writing aleph version")
+        .context("Writing aleph version")?;
+        // Create a symlink so the aleph data is also accessible at the
+        // legacy path.
+        symlink_idempotent(root, BOOTC_ALEPH_PATH, ALEPH_SYMLINK)
+            .context("Creating aleph symlink")?;
+        Ok(())
     }
 }

--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -80,6 +80,29 @@ pub fn have_executable(name: &str) -> Result<bool> {
     Ok(false)
 }
 
+/// Idempotently ensure a symlink `link` -> `target` exists in `dir`.
+///
+/// If the symlink already exists and points to the expected target, this is a
+/// no-op.  If it exists but points elsewhere, it is replaced.
+pub(crate) fn symlink_idempotent(dir: &Dir, target: &str, link: &str) -> Result<()> {
+    match dir.symlink(target, link) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let existing = dir
+                .read_link(link)
+                .with_context(|| format!("Reading existing symlink {link}"))?;
+            if existing == std::path::Path::new(target) {
+                return Ok(());
+            }
+            dir.remove_file(link)
+                .with_context(|| format!("Removing stale symlink {link}"))?;
+            dir.symlink(target, link)
+                .with_context(|| format!("Creating symlink {link} -> {target}"))
+        }
+        Err(e) => Err(e).with_context(|| format!("Creating symlink {link} -> {target}")),
+    }
+}
+
 /// Given a target directory, if it's a read-only mount, then remount it writable
 #[context("Opening {target} with writable mount")]
 pub(crate) fn open_dir_remount_rw(root: &Dir, target: &Utf8Path) -> Result<Dir> {
@@ -335,5 +358,24 @@ mod tests {
     fn test_have_executable() {
         assert!(have_executable("true").unwrap());
         assert!(!have_executable("someexethatdoesnotexist").unwrap());
+    }
+
+    #[test]
+    fn test_symlink_idempotent() {
+        let td = cap_std_ext::cap_tempfile::TempDir::new(
+            cap_std_ext::cap_std::ambient_authority(),
+        )
+        .unwrap();
+        // First call creates the symlink
+        symlink_idempotent(&td, "target-a", "link").unwrap();
+        assert_eq!(td.read_link("link").unwrap(), Path::new("target-a"));
+
+        // Second call with the same target is a no-op
+        symlink_idempotent(&td, "target-a", "link").unwrap();
+        assert_eq!(td.read_link("link").unwrap(), Path::new("target-a"));
+
+        // Call with a different target replaces the symlink
+        symlink_idempotent(&td, "target-b", "link").unwrap();
+        assert_eq!(td.read_link("link").unwrap(), Path::new("target-b"));
     }
 }

--- a/docs/src/bootc-install.md
+++ b/docs/src/bootc-install.md
@@ -544,3 +544,5 @@ filesystem (`.bootc-aleph.json`) containing installation provenance information:
 
 This file is useful for auditing and understanding how a system was provisioned.
 From the booted system, this file is accessible at `/sysroot/.bootc-aleph.json`.
+A compatibility symlink `.aleph-version.json` is also created, pointing to
+`.bootc-aleph.json`.

--- a/tmt/tests/booted/readonly/013-test-aleph.nu
+++ b/tmt/tests/booted/readonly/013-test-aleph.nu
@@ -28,7 +28,13 @@ if $is_composefs {
 } else {
 
     let aleph_path = "/sysroot/.bootc-aleph.json"
+    let symlink_path = "/sysroot/.aleph-version.json"
     let aleph = open $aleph_path
+
+    # Verify that the compatibility symlink exists and points to the aleph file
+    assert (($symlink_path | path exists)) "aleph symlink should exist"
+    let aleph_via_symlink = open $symlink_path
+    assert equal $aleph $aleph_via_symlink "symlink content should match aleph file"
 
     # Verify required fields exist and are non-empty
     assert ($aleph.kernel | is-not-empty) "kernel field should be non-empty"


### PR DESCRIPTION
This adds a compatibility symlink along the created `.bootc-aleph.json` named `.aleph-version.json`.

This compat symlink allow for an easier migration from osbuild's aleph stage [1] to the aleph provided by `bootc install`. This also create a precedent for a "standard" aleph well-known filename that isn't tied to the name of the tool creating it.

Note that coreOS and bootupd relies on this aleph file to exist.

[1] https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.ostree.aleph

See https://github.com/coreos/fedora-coreos-tracker/issues/2187