### PR TITLE
packaging: Drop shim alongside bootupd when switching to systemd-boot

### DIFF
--- a/contrib/packaging/switch-to-sdboot
+++ b/contrib/packaging/switch-to-sdboot
@@ -8,11 +8,26 @@ set -xeuo pipefail
 src=$1/out
 shift
 
-# Uninstall bootupd if present (we're switching to sd-boot managed differently)
-if rpm -q bootupd &>/dev/null; then
-  rpm -e bootupd
-  rm -vrf /usr/lib/bootupd/updates
+# systemd-boot (and, when sealed, the UKI) is signed and booted directly
+# with our own Secure Boot key, so shim is never in the trust chain
+# regardless of sealing. Uninstall bootupd (managed differently for
+# sd-boot) and shim together so neither lingers in the image.
+case "$(uname -m)" in
+  x86_64) shim_pkg=shim-x64 ;;
+  aarch64) shim_pkg=shim-aa64 ;;
+  *) shim_pkg="" ;;
+esac
+
+pkgs_to_remove=()
+for pkg in bootupd "${shim_pkg}"; do
+  [ -n "${pkg}" ] || continue
+  rpm -q "${pkg}" &>/dev/null && pkgs_to_remove+=("${pkg}")
+done
+
+if [ "${#pkgs_to_remove[@]}" -gt 0 ]; then
+  rpm -e "${pkgs_to_remove[@]}"
 fi
+rm -vrf /usr/lib/bootupd/updates
 
 # First install the unsigned systemd-boot RPM to get the package in place
 rpm -Uvh --replacepkgs "${src}"/*.rpm


### PR DESCRIPTION
We sign and boot systemd-boot directly with our own Secure Boot test key (and for sealed images, the UKI itself); shim's chain of trust is never used in either case. Remove shim in the same rpm -e call as bootupd so it doesn't linger in test images, mirroring the same cleanup done in redhat-cop/rhel-bootc-examples#18.

Package name varies by arch (shim-x64 on x86_64, shim-aa64 on aarch64), and neither package is guaranteed to be present, so detect the arch and only remove what's actually installed.

Assisted-by: AI