### PR TITLE
ci: Pin tmt version (to older release) instead of always installing latest

### DIFF
--- a/.github/actions/install-tmt/action.yml
+++ b/.github/actions/install-tmt/action.yml
@@ -1,0 +1,15 @@
+name: 'Install tmt'
+description: 'Install a pinned version of tmt (Test Management Tool)'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install tmt
+      shell: bash
+      run: |
+        set -xeuo pipefail
+        # Pinned because tmt releases have repeatedly regressed reboot
+        # handling for the `connect` provisioner we use here (e.g.
+        # https://github.com/teemtee/tmt/issues/5068); bump deliberately.
+        # renovate: datasource=pypi depName=tmt
+        export VERSION=1.74.0
+        pip install --user "tmt[provision-virtual]==${VERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
         with:
           libvirt: true
       - name: Install tmt
-        run: pip install --user "tmt[provision-virtual]"
+        uses: ./.github/actions/install-tmt
 
       - name: Setup env
         run: |
@@ -380,7 +380,7 @@ jobs:
         with:
           libvirt: true
       - name: Install tmt
-        run: pip install --user "tmt[provision-virtual]"
+        uses: ./.github/actions/install-tmt
 
       - name: Setup env
         run: |
@@ -442,7 +442,7 @@ jobs:
         with:
           libvirt: true
       - name: Install tmt
-        run: pip install --user "tmt[provision-virtual]"
+        uses: ./.github/actions/install-tmt
 
       - name: Setup env
         run: |
@@ -508,7 +508,7 @@ jobs:
         with:
           libvirt: true
       - name: Install tmt
-        run: pip install --user "tmt[provision-virtual]"
+        uses: ./.github/actions/install-tmt
 
       - name: Setup env
         run: |


### PR DESCRIPTION
Agentic investigation points at https://github.com/teemtee/tmt/issues/5068 as a recent source of flakes.

Roll back to an earlier version, and pin to it which can be bumped via renovate.