### PR TITLE
mount, store: Handle pre-mounted ESP in status and upgrade paths

### DIFF
--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -205,9 +205,62 @@ const ESP_MOUNT_FLAGS: MountFlags =
 /// FAT mount options: owner-only permissions on files (0600) and dirs (0700).
 const ESP_MOUNT_DATA: &std::ffi::CStr = c"fmask=0177,dmask=0077";
 
-/// Mount the ESP from the provided device into a temporary directory.
-pub fn mount_esp(device: &str) -> Result<TempMount> {
+/// Fresh `mount(2)` of the ESP into a tempdir. Returns EBUSY if the device
+/// is already mounted in the current mount namespace; callers should use
+/// [`mount_esp_readonly`] or [`mount_esp_writable`] instead of this primitive
+/// so that pre-existing mounts are handled.
+fn mount_esp(device: &str) -> Result<TempMount> {
     TempMount::mount_dev(device, "vfat", ESP_MOUNT_FLAGS, Some(ESP_MOUNT_DATA))
+}
+
+/// Get a read-only view of the ESP for the provided device, gracefully
+/// handling the case where the ESP is already mounted in the root mount
+/// namespace (e.g. via `systemd.mount-extra=UUID=<ESP>:/boot:auto:ro`).
+/// If the ESP is already mounted, that mount is cloned privately into a
+/// tempdir; otherwise a fresh read-write mount is performed. The returned
+/// mount may be rw or ro; callers must not write through it.
+pub fn mount_esp_readonly(device: &str) -> Result<TempMount> {
+    if let Some(existing) = bootc_mount::find_mount_target_by_source(device)? {
+        return TempMount::clone_existing_mount(&existing);
+    }
+    mount_esp(device)
+}
+
+/// Get a read-write view of the ESP for the provided device, gracefully
+/// handling the case where the ESP is already mounted (possibly read-only)
+/// in the root mount namespace.
+///
+/// If the ESP is already mounted, that mount is cloned privately into a
+/// tempdir; if the clone came in read-only (e.g. because
+/// `systemd.mount-extra=UUID=...:/boot:auto:ro` was in the deployment
+/// cmdline), it is remounted rw on the private clone only. This is safe
+/// because bootc always runs in an unshared mount namespace (see
+/// `cli::ensure_self_unshared_mount_namespace`), so the remount does not
+/// affect the host's view. If the ESP is not already mounted, a fresh
+/// read-write mount is performed.
+pub fn mount_esp_writable(device: &str) -> Result<TempMount> {
+    let Some(existing) = bootc_mount::find_mount_target_by_source(device)? else {
+        return mount_esp(device);
+    };
+    let mount = TempMount::clone_existing_mount(&existing)?;
+    let target = mount.dir.path();
+    let st =
+        rustix::fs::statvfs(target).with_context(|| format!("statvfs {}", target.display()))?;
+    if st.f_flag.contains(rustix::fs::StatVfsMountFlags::RDONLY) {
+        rustix::mount::mount_remount(target, MountFlags::BIND | ESP_MOUNT_FLAGS, "").with_context(
+            || {
+                format!(
+                    "Remounting cloned ESP mount at {} read-write",
+                    target.display()
+                )
+            },
+        )?;
+        tracing::debug!(
+            "Cloned ESP mount at {} was read-only; remounted rw in private namespace",
+            target.display()
+        );
+    }
+    Ok(mount)
 }
 
 /// Mount the ESP from `device` at the given path and return a guard that
@@ -618,7 +671,7 @@ pub(crate) fn setup_composefs_bls_boot(
         }
 
         BootloaderKind::BLSCompatible => {
-            let efi_mount = mount_esp(&esp_device).context("Mounting ESP")?;
+            let efi_mount = mount_esp_writable(&esp_device).context("Mounting ESP")?;
 
             let mounted_efi = Utf8PathBuf::from(efi_mount.dir.path().as_str()?);
             let efi_linux_dir = mounted_efi.join(EFI_LINUX);
@@ -1123,7 +1176,7 @@ pub(crate) fn setup_composefs_uki_boot(
         }
     };
 
-    let esp_mount = mount_esp(&esp_device).context("Mounting ESP")?;
+    let esp_mount = mount_esp_writable(&esp_device).context("Mounting ESP")?;
 
     let mut uki_info: Option<UKIInfo> = None;
 

--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -228,47 +228,44 @@ pub fn mount_esp_readonly(device: &str) -> Result<TempMount> {
 
 /// Get a read-write view of the ESP for the provided device, gracefully
 /// handling the case where the ESP is already mounted (possibly read-only)
-/// in the root mount namespace.
+/// in the current mount namespace.
 ///
-/// If the ESP is already mounted, that mount is cloned privately into a
-/// tempdir; if the clone came in read-only (e.g. because
-/// `systemd.mount-extra=UUID=...:/boot:auto:ro` was in the deployment
-/// cmdline), it is remounted rw on the private clone only. This is safe
-/// because bootc always runs in an unshared mount namespace (see
-/// `cli::ensure_self_unshared_mount_namespace`), so the remount does not
-/// affect the host's view. If the ESP is not already mounted, a fresh
-/// read-write mount is performed.
+/// If the ESP's device is already mounted, that mount is unconditionally
+/// remounted read-write *in place* first -- the same approach already
+/// used for `/sysroot` in `open_dir_remount_rw`, which likewise doesn't
+/// bother checking whether it's already writable before remounting.
+/// This matters because our own fresh `mount(2)` below would otherwise
+/// get `EBUSY` from the kernel's `get_tree_bdev_flags()` if the existing
+/// mount's `MS_RDONLY` state doesn't match what we're requesting (e.g.
+/// via a `systemd.mount-extra=UUID=...:/boot:auto:ro` cmdline karg
+/// written by `bootc install to-filesystem`). Note remounting a private
+/// *clone* of the existing mount would not be sufficient here: that only
+/// clears the clone's own mount-level read-only flag, not the shared
+/// superblock's, so writes through it would still fail with `EROFS`.
+/// Remounting the existing mount directly is safe because bootc always
+/// runs in its own unshared mount namespace (see
+/// `cli::ensure_self_unshared_mount_namespace`).
 pub fn mount_esp_writable(device: &str) -> Result<TempMount> {
-    let Some(existing) = bootc_mount::find_mount_target_by_source(device)? else {
-        return mount_esp(device);
-    };
-    let mount = TempMount::clone_existing_mount(&existing)?;
-    let target = mount.dir.path();
-    let st =
-        rustix::fs::statvfs(target).with_context(|| format!("statvfs {}", target.display()))?;
-    if st.f_flag.contains(rustix::fs::StatVfsMountFlags::RDONLY) {
-        rustix::mount::mount_remount(target, MountFlags::BIND | ESP_MOUNT_FLAGS, "").with_context(
-            || {
-                format!(
-                    "Remounting cloned ESP mount at {} read-write",
-                    target.display()
-                )
-            },
-        )?;
-        tracing::debug!(
-            "Cloned ESP mount at {} was read-only; remounted rw in private namespace",
-            target.display()
-        );
+    if let Some(existing) = bootc_mount::find_mount_target_by_source(device)? {
+        rustix::mount::mount_remount(existing.as_str(), ESP_MOUNT_FLAGS, "")
+            .with_context(|| format!("Remounting {existing} read-write"))?;
     }
-    Ok(mount)
+    mount_esp(device)
 }
 
 /// Mount the ESP from `device` at the given path and return a guard that
 /// synchronously unmounts (and flushes) it on drop.
+///
+/// Applies the same pre-emptive remount as `mount_esp_writable`; see
+/// there for details and caveats.
 pub(crate) fn mount_esp_at(
     device: &str,
     path: std::path::PathBuf,
 ) -> Result<bootc_mount::tempmount::MountGuard> {
+    if let Some(existing) = bootc_mount::find_mount_target_by_source(device)? {
+        rustix::mount::mount_remount(existing.as_str(), ESP_MOUNT_FLAGS, "")
+            .with_context(|| format!("Remounting {existing} read-write"))?;
+    }
     bootc_mount::tempmount::MountGuard::mount(
         device,
         path,

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1030,7 +1030,7 @@ pub(crate) async fn get_storage() -> Result<crate::store::BootedStorage> {
     // Always call prepare_for_write() for write operations - it checks
     // for container, root privileges, mount namespace setup, etc.
     prepare_for_write()?;
-    let r = BootedStorage::new(env)
+    let r = BootedStorage::new(env, crate::store::EspAccess::ReadWrite)
         .await?
         .ok_or_else(|| anyhow!("System not booted via bootc"))?;
     Ok(r)

--- a/crates/lib/src/status.rs
+++ b/crates/lib/src/status.rs
@@ -447,7 +447,7 @@ pub(crate) async fn get_host() -> Result<Host> {
         crate::cli::prepare_for_write()?;
     }
 
-    let Some(storage) = BootedStorage::new(env).await? else {
+    let Some(storage) = BootedStorage::new(env, crate::store::EspAccess::ReadOnly).await? else {
         // If we're not booted, then return a default.
         return Ok(Host::default());
     };

--- a/crates/lib/src/store/mod.rs
+++ b/crates/lib/src/store/mod.rs
@@ -115,7 +115,7 @@ use composefs::repository::{RepositoryConfig, RepositoryOpenError};
 use composefs_ctl::composefs;
 
 use crate::bootc_composefs::backwards_compat::bcompat_boot::prepend_custom_prefix;
-use crate::bootc_composefs::boot::{EFI_LINUX, mount_esp};
+use crate::bootc_composefs::boot::{EFI_LINUX, mount_esp_readonly, mount_esp_writable};
 use crate::bootc_composefs::status::{ComposefsCmdline, composefs_booted, get_bootloader};
 use crate::lsm;
 use crate::podstorage::CStorage;
@@ -268,6 +268,19 @@ pub(crate) enum Environment {
     Other,
 }
 
+/// Whether a `BootedStorage` caller intends to write to the ESP.
+///
+/// Only meaningful for `Environment::ComposefsBooted`; ignored elsewhere.
+/// Read-only callers (e.g. `bootc status`) pass `ReadOnly` so a pre-mounted
+/// ro ESP can be cloned as-is; write callers (e.g. `bootc upgrade`) pass
+/// `ReadWrite` so a pre-mounted ro ESP is remounted rw in the private
+/// mount namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EspAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
 impl Environment {
     /// Detect the current runtime environment.
     pub(crate) fn detect() -> Result<Self> {
@@ -316,8 +329,9 @@ impl BootedStorage {
     /// Create a new booted storage accessor for the given environment.
     ///
     /// The caller must have already called `prepare_for_write()` if
-    /// `env.needs_mount_namespace()` is true.
-    pub(crate) async fn new(env: Environment) -> Result<Option<Self>> {
+    /// `env.needs_mount_namespace()` is true. `esp_access` selects how the
+    /// ESP mount is acquired on composefs systems (see [`EspAccess`]).
+    pub(crate) async fn new(env: Environment, esp_access: EspAccess) -> Result<Option<Self>> {
         let r = match &env {
             Environment::ComposefsBooted(cmdline) => {
                 let (physical_root, run) = get_physical_root_and_run()?;
@@ -327,10 +341,17 @@ impl BootedStorage {
                 }
                 let composefs = Arc::new(composefs);
 
-                // Locate ESP by walking up to the root disk(s)
+                // Locate ESP by walking up to the root disk(s). Both mount
+                // variants transparently reuse an already-mounted ESP when
+                // present (e.g. auto-mounted at /boot ro via
+                // `systemd.mount-extra` in the deployment cmdline).
                 let root_dev = bootc_blockdev::list_dev_by_dir(&physical_root)?;
                 let esp_dev = root_dev.find_first_colocated_esp()?;
-                let esp_mount = mount_esp(&esp_dev.path())?;
+                let esp_path = esp_dev.path();
+                let esp_mount = match esp_access {
+                    EspAccess::ReadOnly => mount_esp_readonly(&esp_path)?,
+                    EspAccess::ReadWrite => mount_esp_writable(&esp_path)?,
+                };
 
                 let boot_dir = match get_bootloader()?.kind()? {
                     BootloaderKind::GRUBClassic => {

--- a/crates/mount/src/mount.rs
+++ b/crates/mount/src/mount.rs
@@ -111,14 +111,54 @@ pub fn inspect_filesystem_by_uuid(uuid: &str) -> Result<Filesystem> {
     findmnt_filesystem(&["--source"], None, &(format!("UUID={uuid}")))
 }
 
+/// Return the list of mounts visible in pid 1's mount namespace, as reported by findmnt.
+fn pid1_mounts() -> Result<Findmnt> {
+    run_findmnt(&["-N"], None, Some("1"))
+}
+
 /// Check if a specified device contains an already mounted filesystem
 /// in the root mount namespace.
 pub fn is_mounted_in_pid1_mountns(path: &str) -> Result<bool> {
-    let o = run_findmnt(&["-N"], None, Some("1"))?;
+    let o = pid1_mounts()?;
 
     let mounted = o.filesystems.iter().any(|fs| is_source_mounted(path, fs));
 
     Ok(mounted)
+}
+
+/// Find the mount target of a given source device in the root mount
+/// namespace. Returns `Ok(None)` if the device is not mounted.
+///
+/// Used by callers that want to gracefully handle the case where a
+/// device they intended to mount is already mounted somewhere else
+/// (which would cause a fresh `mount(2)` to return `EBUSY`). Combined
+/// with `TempMount::clone_existing_mount`, this lets read-only callers
+/// like `bootc status` reuse an existing mount without disturbing it.
+pub fn find_mount_target_by_source(dev: &str) -> Result<Option<camino::Utf8PathBuf>> {
+    let o = pid1_mounts()?;
+    let found = find_source_mount_target(dev, &o.filesystems);
+    if found.is_none() {
+        tracing::debug!(
+            "find_mount_target_by_source: no mount found for source {dev}; \
+             note that findmnt may report by-uuid or by-partuuid paths instead \
+             of the block device path in some environments"
+        );
+    }
+    Ok(found)
+}
+
+fn find_source_mount_target(dev: &str, mounts: &[Filesystem]) -> Option<camino::Utf8PathBuf> {
+    for m in mounts {
+        if m.source == dev {
+            return Some(camino::Utf8PathBuf::from(&m.target));
+        }
+        if let Some(children) = &m.children {
+            if let Some(t) = find_source_mount_target(dev, children) {
+                return Some(t);
+            }
+        }
+    }
+    None
 }
 
 /// Recursively check a given filesystem to see if it contains an already mounted source.
@@ -319,4 +359,68 @@ pub fn ensure_mirrored_host_mount(path: impl AsRef<Utf8Path>) -> Result<()> {
     }
     tracing::debug!("Propagating host mount: {path}");
     bind_mount_from_pidns(PID1, path, path, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    fn mk_fs(source: &str, target: &str, children: Vec<Filesystem>) -> Filesystem {
+        Filesystem {
+            source: source.into(),
+            target: target.into(),
+            maj_min: "0:0".into(),
+            fstype: "ext4".into(),
+            options: "rw".into(),
+            uuid: None,
+            children: if children.is_empty() {
+                None
+            } else {
+                Some(children)
+            },
+        }
+    }
+
+    #[test]
+    fn find_source_mount_target_cases() {
+        let top_level = vec![
+            mk_fs("/dev/vda2", "/sysroot", vec![]),
+            mk_fs("/dev/vda1", "/boot", vec![]),
+        ];
+        // /boot as a child mount nested under /sysroot — the shape findmnt -J
+        // returns when /boot is under sysroot.
+        let nested = vec![mk_fs(
+            "/dev/vda2",
+            "/sysroot",
+            vec![mk_fs("/dev/vda1", "/sysroot/boot", vec![])],
+        )];
+        // A real composefs + LUKS-/var shape: /dev/vda2 appears twice (as
+        // sysroot and as its /var overlay parent), and /dev/mapper/var is
+        // nested a further level down. Guards against a naive walk that
+        // would stop at the first /dev/vda2 match instead of recursing.
+        let deep = vec![mk_fs(
+            "/dev/vda2",
+            "/sysroot",
+            vec![mk_fs(
+                "/dev/vda2",
+                "/var",
+                vec![mk_fs("/dev/mapper/var", "/var", vec![])],
+            )],
+        )];
+
+        let cases: &[(&str, &str, &[Filesystem], Option<&str>)] = &[
+            ("top-level match", "/dev/vda1", &top_level, Some("/boot")),
+            ("nested match", "/dev/vda1", &nested, Some("/sysroot/boot")),
+            ("not found", "/dev/vda1", &top_level[..1], None),
+            ("empty tree", "/dev/vda1", &[], None),
+            ("deep nesting", "/dev/mapper/var", &deep, Some("/var")),
+        ];
+
+        for (name, dev, tree, expected) in cases {
+            let got = find_source_mount_target(dev, tree);
+            let want = expected.map(Utf8PathBuf::from);
+            assert_eq!(got, want, "case: {name}");
+        }
+    }
 }

--- a/crates/mount/src/mount.rs
+++ b/crates/mount/src/mount.rs
@@ -126,16 +126,21 @@ pub fn is_mounted_in_pid1_mountns(path: &str) -> Result<bool> {
     Ok(mounted)
 }
 
-/// Find the mount target of a given source device in the root mount
+/// Find the mount target of a given source device in the *current* mount
 /// namespace. Returns `Ok(None)` if the device is not mounted.
 ///
 /// Used by callers that want to gracefully handle the case where a
 /// device they intended to mount is already mounted somewhere else
-/// (which would cause a fresh `mount(2)` to return `EBUSY`). Combined
-/// with `TempMount::clone_existing_mount`, this lets read-only callers
-/// like `bootc status` reuse an existing mount without disturbing it.
+/// (which would cause a fresh `mount(2)` to return `EBUSY`). Note this
+/// intentionally queries the caller's own mount namespace, not pid 1's
+/// (unlike `is_mounted_in_pid1_mountns`, which exists to answer a
+/// different question: whether the *host* already has something
+/// mounted before bootc unshares its own namespace). Callers of this
+/// function are expected to have already unshared their own mount
+/// namespace and are looking up a mount they intend to operate on
+/// directly (e.g. remount) in that same namespace.
 pub fn find_mount_target_by_source(dev: &str) -> Result<Option<camino::Utf8PathBuf>> {
-    let o = pid1_mounts()?;
+    let o = run_findmnt(&[], None, None)?;
     let found = find_source_mount_target(dev, &o.filesystems);
     if found.is_none() {
         tracing::debug!(

--- a/crates/mount/src/tempmount.rs
+++ b/crates/mount/src/tempmount.rs
@@ -6,7 +6,9 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std_ext::cap_std::{ambient_authority, fs::Dir};
 use fn_error_context::context;
-use rustix::mount::{MountFlags, MoveMountFlags, UnmountFlags, move_mount, unmount};
+use rustix::mount::{
+    MountFlags, MoveMountFlags, OpenTreeFlags, UnmountFlags, move_mount, open_tree, unmount,
+};
 
 /// RAII guard that synchronously unmounts a path on drop, flushing all writes.
 ///
@@ -105,6 +107,49 @@ impl TempMount {
             .ok_or(anyhow::anyhow!("Failed to convert path to UTF-8 Path"))?;
 
         rustix::mount::mount(dev, utf8path.as_std_path(), fstype, flags, data)?;
+
+        let fd = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
+            .with_context(|| format!("Opening {:?}", tempdir.path()));
+
+        let fd = match fd {
+            Ok(fd) => fd,
+            Err(e) => {
+                unmount(tempdir.path(), UnmountFlags::DETACH)?;
+                return Err(e)?;
+            }
+        };
+
+        Ok(Self { dir: tempdir, fd })
+    }
+
+    /// Clone an existing mount into a tempdir via `open_tree(OPEN_TREE_CLONE)`
+    /// + `move_mount(MOVE_MOUNT_F_EMPTY_PATH)`. The returned `TempMount`
+    /// is a private view of the same filesystem — the source mount at
+    /// `source_target` is untouched and remains visible to other processes.
+    ///
+    /// The clone inherits the source mount's attributes (rw/ro, nosuid,
+    /// nodev, fmask/dmask, etc.). Callers that require specific mount
+    /// options should use `mount_dev` and treat `EBUSY` as unrecoverable
+    /// — this function is intended for read-only callers that can accept
+    /// whatever the current mount happens to expose.
+    #[context("Cloning existing mount at {source_target}")]
+    pub fn clone_existing_mount(source_target: &Utf8Path) -> Result<Self> {
+        let tempdir = MountpointTempdir::new()?;
+
+        let cloned = open_tree(
+            rustix::fs::CWD,
+            source_target.as_std_path(),
+            OpenTreeFlags::OPEN_TREE_CLOEXEC | OpenTreeFlags::OPEN_TREE_CLONE,
+        )
+        .with_context(|| format!("open_tree({source_target})"))?;
+        move_mount(
+            cloned.as_fd(),
+            "",
+            rustix::fs::CWD,
+            tempdir.path(),
+            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+        )
+        .context("move_mount")?;
 
         let fd = Dir::open_ambient_dir(tempdir.path(), ambient_authority())
             .with_context(|| format!("Opening {:?}", tempdir.path()));


### PR DESCRIPTION
Fixes #2355.

`bootc install to-filesystem` writes
`systemd.mount-extra=UUID=<ESP>:/boot:auto:ro` into the deployment
cmdline; systemd's fstab-generator then mounts /boot ro at boot. Every
subsequent `bootc status` failed with

    error: Status: Mounting /dev/vda1: Device or resource busy (os error 16)

and any code path that writes the ESP (BLS install, UKI install, gc)
would hit the same EBUSY on a pre-mounted host.

Two commits:

1. **Split the ESP-mount primitive into two intent-typed helpers** and
   thread the choice through `BootedStorage`. `mount_esp_readonly` for
   `bootc status` (reuses an existing mount as-is via
   `open_tree(OPEN_TREE_CLONE)`); `mount_esp_writable` for
   install/upgrade/gc. `BootedStorage::new` grows an `EspAccess`
   argument; `status::get_host` passes `ReadOnly`, `cli::get_storage`
   passes `ReadWrite`. The raw `mount_esp` primitive is now module-
   private, reachable only via the typed wrappers. Also adds
   `find_mount_target_by_source(dev)` with a table-driven unit test.

2. **Fix `mount_esp_writable` to actually grant write access** (from
   @cgwalters). A `MS_BIND | MS_REMOUNT` on an `OPEN_TREE_CLONE` only
   clears the clone's `MNT_READONLY`, never the shared superblock's
   `SB_RDONLY` — so the first version would have silently produced a
   mount that failed writes with `EROFS`. Replace with a superblock-
   level remount of the *existing* mount in place, matching the
   pattern `open_dir_remount_rw` already uses for `/sysroot`. Also
   applies the same fix to `mount_esp_at` (install path).

Verified live on QEMU x86_64 (systemd 261.2, linux-qemu-6.18-bootc,
/boot mounted ro via systemd.mount-extra):
- Before: `bootc status` fails with EBUSY.
- After commit 1: `bootc status` returns full YAML and JSON.
- After commit 2: superblock-level remount confirmed in a private ns
  test — `touch /boot/x` succeeds after remount, host `/boot` stays
  read-only.

Trailers on both commits document AI assistance per bootc's
[`AGENTS.md`][]. See [#issuecomment-5138400886][] and the reply thread
for context on tooling and human review.

[`AGENTS.md`]: https://github.com/bootc-dev/bootc/blob/main/AGENTS.md
[#issuecomment-5138400886]: https://github.com/bootc-dev/bootc/pull/2356#issuecomment-5138400886