### PR TITLE
tmpfiles: Canonicalize declared tmpfiles.d paths against the rootfs

### DIFF
--- a/crates/tmpfiles/src/lib.rs
+++ b/crates/tmpfiles/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fmt::Write as WriteFmt;
 use std::io::{BufRead, BufReader, Write as StdWrite};
 use std::iter::Peekable;
@@ -18,6 +18,9 @@ use cap_std_ext::dirext::CapStdExtDirExt;
 use rustix::fs::Mode;
 use rustix::path::Arg;
 use thiserror::Error;
+
+mod path_resolution;
+use path_resolution::{PathIdentity, PathResolver};
 
 const TMPFILESD: &str = "usr/lib/tmpfiles.d";
 const ETC_TMPFILESD: &str = "etc/tmpfiles.d";
@@ -164,17 +167,21 @@ where
     Ok(PathBuf::from(r))
 }
 
-/// Canonicalize and escape a path value for tmpfiles.d
-/// At the current time the only canonicalization we do is remap /var/run -> /run.
+/// Canonicalize and escape a path value for tmpfiles.d.
+///
+/// This performs one canonicalization: remapping `/var/run` -> `/run`. This
+/// is hardcoded because `/var/run` is itself required to be a symlink
+/// pointing *out* to the real `/run` (see `Error::FoundVarRunNonSymlink`).
+/// The walker never recurses into `/var/run`, so this rewrite only ever
+/// applies to the top-level entry itself.
 fn canonicalize_escape_path<W: std::fmt::Write>(path: &Path, out: &mut W) -> std::fmt::Result {
-    // systemd-tmpfiles complains loudly about writing to /var/run;
-    // ideally, all of the packages get fixed for this but...eh.
-    let path = if path.starts_with("/var/run") {
-        let rest = &path.as_os_str().as_bytes()[4..];
-        Path::new(OsStr::from_bytes(rest))
-    } else {
-        path
-    };
+    if let Ok(rest) = path.strip_prefix("/var/run") {
+        let mut rewritten = PathBuf::from("/run");
+        if !rest.as_os_str().is_empty() {
+            rewritten.push(rest);
+        }
+        return escape_path(&rewritten, out);
+    }
     escape_path(path, out)
 }
 
@@ -263,6 +270,7 @@ pub fn var_to_tmpfiles<U: uzers::Users, G: uzers::Groups>(
     let mut entries = BTreeSet::new();
     let mut prefix = PathBuf::from("/var");
     let mut unsupported = Vec::new();
+    let var_identity = dir_dev_ino(rootfs, "var")?;
     convert_path_to_tmpfiles_d_recurse(
         &TmpfilesConvertConfig {
             users,
@@ -274,6 +282,7 @@ pub fn var_to_tmpfiles<U: uzers::Users, G: uzers::Groups>(
         &mut entries,
         &mut unsupported,
         &mut prefix,
+        var_identity,
     )?;
 
     // If there's no entries, don't write a file
@@ -312,12 +321,23 @@ pub fn var_to_tmpfiles<U: uzers::Users, G: uzers::Groups>(
     })
 }
 
+/// The `(dev, ino)` identity of `path` (relative to `dir`), used as the
+/// "parent" half of a [`PathIdentity`] lookup key.
+fn dir_dev_ino(dir: &Dir, path: &str) -> Result<(u64, u64)> {
+    let meta = dir.metadata(path)?;
+    Ok((meta.dev(), meta.ino()))
+}
+
 /// Configuration for recursive tmpfiles conversion
 struct TmpfilesConvertConfig<'a, U: uzers::Users, G: uzers::Groups> {
     users: &'a U,
     groups: &'a G,
     rootfs: &'a Dir,
-    existing: &'a BTreeMap<PathBuf, String>,
+    /// tmpfiles.d entries already declared for `/var`, keyed by the
+    /// *physical identity* of their resolved location (see
+    /// `PathResolver::resolve_parent_identity`), matching what this walker
+    /// actually encounters on disk.
+    existing: &'a BTreeMap<PathIdentity, String>,
     readonly: bool,
 }
 
@@ -332,15 +352,20 @@ fn convert_path_to_tmpfiles_d_recurse<U: uzers::Users, G: uzers::Groups>(
     out_entries: &mut BTreeSet<String>,
     out_unsupported: &mut Vec<PathBuf>,
     prefix: &mut PathBuf,
+    dir_identity: (u64, u64),
 ) -> Result<()> {
     let relpath = prefix.strip_prefix("/").unwrap();
     for subpath in config.rootfs.read_dir(relpath)? {
         let subpath = subpath?;
         let meta = subpath.metadata()?;
         let fname = subpath.file_name();
-        prefix.push(fname);
+        prefix.push(&fname);
 
-        let has_tmpfiles_entry = config.existing.contains_key(prefix);
+        // `existing` is keyed by physical identity (see
+        // `PathResolver::resolve_parent_identity`), matching what we
+        // encounter here directly -- no alias lookup needed.
+        let key = PathIdentity::new(dir_identity.0, dir_identity.1, fname);
+        let has_tmpfiles_entry = config.existing.contains_key(&key);
 
         // Translate this file entry.
         if !has_tmpfiles_entry {
@@ -381,8 +406,18 @@ fn convert_path_to_tmpfiles_d_recurse<U: uzers::Users, G: uzers::Groups>(
             // SAFETY: We know this path is absolute
             let relpath = prefix.strip_prefix("/").unwrap();
             // Avoid traversing mount points by default
-            if config.rootfs.open_dir_noxdev(relpath)?.is_some() {
-                convert_path_to_tmpfiles_d_recurse(config, out_entries, out_unsupported, prefix)?;
+            if let Some(subdir) = config.rootfs.open_dir_noxdev(relpath)? {
+                // Reuse the fd we just opened (to decide whether to recurse)
+                // to also cheaply get this subdirectory's own identity, so
+                // we only pay for one `fstat` per *directory*, not per file.
+                let sub_meta = subdir.dir_metadata()?;
+                convert_path_to_tmpfiles_d_recurse(
+                    config,
+                    out_entries,
+                    out_unsupported,
+                    prefix,
+                    (sub_meta.dev(), sub_meta.ino()),
+                )?;
                 let relpath = prefix.strip_prefix("/").unwrap();
                 if !config.readonly {
                     config.rootfs.remove_dir_all(relpath)?;
@@ -435,6 +470,7 @@ pub fn find_missing_tmpfiles_current_root() -> Result<TmpfilesResult> {
     let mut prefix = PathBuf::from("/var");
     let mut tmpfiles = BTreeSet::new();
     let mut unsupported = Vec::new();
+    let var_identity = dir_dev_ino(&rootfs, "var")?;
     convert_path_to_tmpfiles_d_recurse(
         &TmpfilesConvertConfig {
             users: &usergroups,
@@ -446,6 +482,7 @@ pub fn find_missing_tmpfiles_current_root() -> Result<TmpfilesResult> {
         &mut tmpfiles,
         &mut unsupported,
         &mut prefix,
+        var_identity,
     )?;
     Ok(TmpfilesResult {
         tmpfiles,
@@ -453,12 +490,15 @@ pub fn find_missing_tmpfiles_current_root() -> Result<TmpfilesResult> {
     })
 }
 
-/// Read all tmpfiles.d entries from a single directory
+/// Read all tmpfiles.d entries from a single directory. Declared paths are
+/// canonicalized against `rootfs` (see `PathResolver`) so the returned map is
+/// keyed by physical identity.
 fn read_tmpfiles_from_dir(
     rootfs: &Dir,
     dir_path: &str,
+    resolver: &PathResolver,
     generation: &mut BootcTmpfilesGeneration,
-) -> Result<BTreeMap<PathBuf, String>> {
+) -> Result<BTreeMap<PathIdentity, String>> {
     let Some(tmpfiles_dir) = rootfs.open_dir_optional(dir_path)? else {
         return Ok(Default::default());
     };
@@ -486,7 +526,18 @@ fn read_tmpfiles_from_dir(
                 continue;
             }
             let path = tmpfiles_entry_get_path(&line)?;
-            result.insert(path.to_owned(), line);
+            // Canonicalize against the physical rootfs so `existing` is keyed
+            // by the identity of what the `/var` walker actually encounters
+            // on disk (e.g. `/root/.ssh` -> the identity of
+            // `/var/roothome/.ssh`), rather than the raw declared path. See
+            // `PathResolver`.
+            let Some(identity) = resolver.resolve_parent_identity(&path)? else {
+                // Nothing can physically exist beneath a missing parent
+                // directory, so the `/var` walker will never need to match
+                // this declared entry anyway.
+                continue;
+            };
+            result.insert(identity, line);
         }
     }
     Ok(result)
@@ -497,14 +548,17 @@ fn read_tmpfiles_from_dir(
 ///
 /// This function reads from both `/usr/lib/tmpfiles.d` and `/etc/tmpfiles.d`,
 /// with `/etc` entries taking precedence (matching systemd's behavior).
-fn read_tmpfiles(rootfs: &Dir) -> Result<(BTreeMap<PathBuf, String>, BootcTmpfilesGeneration)> {
+fn read_tmpfiles(
+    rootfs: &Dir,
+) -> Result<(BTreeMap<PathIdentity, String>, BootcTmpfilesGeneration)> {
     let mut generation = BootcTmpfilesGeneration::default();
+    let resolver = PathResolver::new(rootfs)?;
 
     // Read from /usr/lib/tmpfiles.d first (system/package-provided)
-    let mut result = read_tmpfiles_from_dir(rootfs, TMPFILESD, &mut generation)?;
+    let mut result = read_tmpfiles_from_dir(rootfs, TMPFILESD, &resolver, &mut generation)?;
 
     // Read from /etc/tmpfiles.d and merge (user-provided, takes precedence)
-    let etc_result = read_tmpfiles_from_dir(rootfs, ETC_TMPFILESD, &mut generation)?;
+    let etc_result = read_tmpfiles_from_dir(rootfs, ETC_TMPFILESD, &resolver, &mut generation)?;
     // /etc entries override /usr/lib entries for the same path
     result.extend(etc_result);
 
@@ -653,6 +707,92 @@ mod tests {
         Ok(())
     }
 
+    /// Verify that a physical path under /var is recognized as covered by a
+    /// tmpfiles.d entry declared via its conventional alias, e.g. systemd's
+    /// `provision.conf` declares `/root/.ssh` even though on stateless-root
+    /// systems `/root` is a symlink to the physical `/var/roothome`. The
+    /// symlink is resolved against the real rootfs at match time, so this
+    /// works for whatever alias happens to be present there.
+    #[test]
+    fn test_tmpfiles_d_root_alias() -> anyhow::Result<()> {
+        // Prepare a minimal rootfs as playground.
+        let rootfs = &newroot()?;
+        let userdb = &mock_userdb();
+
+        rootfs.write(
+            Path::new(TMPFILESD).join("systemd.conf"),
+            indoc::indoc! { r#"
+            d /var/roothome 0700 root root -
+            d /root/.ssh 0700 root root -
+        "#},
+        )?;
+
+        rootfs.create_dir_all("var/roothome/.ssh")?;
+        rootfs.symlink("var/roothome", "root")?;
+
+        let w = var_to_tmpfiles(rootfs, userdb, userdb).unwrap();
+        assert_eq!(w.unsupported, 0);
+        assert!(w.generated.is_none());
+
+        Ok(())
+    }
+
+    /// A second, differently-named alias scenario (using an absolute symlink
+    /// target this time), proving resolution isn't special-cased to `/root`.
+    #[test]
+    fn test_tmpfiles_d_home_alias() -> anyhow::Result<()> {
+        // Prepare a minimal rootfs as playground.
+        let rootfs = &newroot()?;
+        let userdb = &mock_userdb();
+
+        rootfs.write(
+            Path::new(TMPFILESD).join("systemd.conf"),
+            indoc::indoc! { r#"
+            d /var/home 0755 root root -
+            d /home/testuser 0700 testuser testuser -
+        "#},
+        )?;
+
+        rootfs.create_dir_all("var/home/testuser")?;
+        rootfs.symlink_contents("/var/home", "home")?;
+
+        let w = var_to_tmpfiles(rootfs, userdb, userdb).unwrap();
+        assert_eq!(w.unsupported, 0);
+        assert!(w.generated.is_none());
+
+        Ok(())
+    }
+
+    /// Like `test_tmpfiles_d_root_alias`, but the symlink is nested two
+    /// levels deep under /var instead of being a top-level entry, proving
+    /// `PathResolver::resolve_parent_identity` resolves symlinks anywhere
+    /// along the path, not just at the top level.
+    #[test]
+    fn test_tmpfiles_d_nested_symlink() -> anyhow::Result<()> {
+        // Prepare a minimal rootfs as playground.
+        let rootfs = &newroot()?;
+        let userdb = &mock_userdb();
+
+        rootfs.write(
+            Path::new(TMPFILESD).join("systemd.conf"),
+            indoc::indoc! { r#"
+            d /var/lib 0755 root root -
+            d /var/lib/machines 0755 root root -
+            L /var/lib/portables - - - - machines
+            d /var/lib/portables/myimage 0755 root root -
+        "#},
+        )?;
+
+        rootfs.create_dir_all("var/lib/machines/myimage")?;
+        rootfs.symlink("machines", "var/lib/portables")?;
+
+        let w = var_to_tmpfiles(rootfs, userdb, userdb).unwrap();
+        assert_eq!(w.unsupported, 0);
+        assert!(w.generated.is_none());
+
+        Ok(())
+    }
+
     /// Verify that we emit ignores for regular files
     #[test]
     fn test_log_regfile() -> anyhow::Result<()> {
@@ -685,6 +825,7 @@ mod tests {
             similar_asserts::assert_eq!(&s, entry);
         }
 
+        // The /var/run -> /run rewrite remains hardcoded.
         let quoting_cases = &[
             ("/var/foo bar", r#"/var/foo\x20bar"#),
             ("/var/run", "/run"),

--- a/crates/tmpfiles/src/path_resolution.rs
+++ b/crates/tmpfiles/src/path_resolution.rs
@@ -1,0 +1,290 @@
+//! Generic primitives for resolving a path against real symlinks in a
+//! `cap_std::fs::Dir`-rooted filesystem.
+
+use std::ffi::OsString;
+use std::os::unix::fs::MetadataExt as _;
+use std::path::Path;
+
+use cap_std::fs::{Dir, MetadataExt as _};
+use cap_std_ext::RootDir;
+use cap_std_ext::cap_std;
+
+use crate::{Error, Result};
+
+/// The physical identity of a resolved path: the `(dev, ino)` of its
+/// (symlink-resolved) parent directory, paired with its own leaf filename.
+///
+/// The leaf is never dereferenced (see [`PathResolver::resolve_parent_identity`]),
+/// so it's kept as a plain filename rather than being folded into the parent
+/// identity.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PathIdentity {
+    parent_dev: u64,
+    parent_ino: u64,
+    leaf: OsString,
+}
+
+impl PathIdentity {
+    pub(crate) fn new(parent_dev: u64, parent_ino: u64, leaf: OsString) -> Self {
+        Self {
+            parent_dev,
+            parent_ino,
+            leaf,
+        }
+    }
+}
+
+/// Resolves the symlinks in the *parent* (intermediate) components of a
+/// declared tmpfiles.d path against the physical rootfs, so that it matches
+/// what the `/var` walker in `convert_path_to_tmpfiles_d_recurse` actually
+/// encounters on disk.
+///
+/// For example, systemd's `provision.conf` declares `d /root/.ssh ...`, but
+/// on a stateless/immutable-root system `/root` is a symlink to the physical
+/// `/var/roothome`, so the walker only ever sees `/var/roothome/.ssh`.
+/// Resolving `/root/.ssh` here to the *identity* of `/var/roothome/.ssh`
+/// lets a plain map lookup recognize it as covered, without the walker
+/// having to do a bidirectional alias lookup at every node.
+///
+/// The **leaf** (final) component of a path is never dereferenced, even if
+/// it happens to be a symlink itself: it's the thing being declared by the
+/// tmpfiles.d line, may not exist yet, and its own target is irrelevant to
+/// resolving its *location*. Only the parent directory is ever opened.
+///
+/// Resolution of the parent is delegated entirely to the kernel via
+/// `openat2(RESOLVE_IN_ROOT)` (through [`cap_std_ext::RootDir`]), which
+/// correctly and safely handles arbitrary symlink chains, absolute symlink
+/// targets (chroot-style reinterpreted against the rootfs, e.g. a top-level
+/// `/home -> /var/home`), and symlink loops (surfaced as a standard `ELOOP`
+/// I/O error), without this crate needing to reimplement any of that itself.
+///
+/// Since the kernel has already done the real work of resolving the parent
+/// down to a live, open file descriptor, the result is reported as that
+/// descriptor's `(dev, ino)` identity (via `fstat`). Querying identity
+/// directly on an already-open fd is kernel-authoritative and immune to
+/// concurrent path mutations (renames of ancestors, etc.).
+///
+/// If any component of the parent doesn't exist, `Ok(None)` is returned:
+/// nothing can physically exist beneath a missing directory either, so the
+/// `/var` walker will never encounter (and thus never need to match) such a
+/// path in the first place.
+pub(crate) struct PathResolver {
+    root_dir: RootDir,
+    /// The `(dev, ino)` identity of the rootfs root itself, captured once so
+    /// that resolving a bare top-level entry (whose "parent" is the rootfs
+    /// root, which can't itself be a symlink) doesn't need a separate lookup.
+    root_dev: u64,
+    root_ino: u64,
+}
+
+impl PathResolver {
+    pub(crate) fn new(rootfs: &Dir) -> Result<Self> {
+        let root_dir = RootDir::new(rootfs, ".")?;
+        let root_meta = rootfs.dir_metadata()?;
+        Ok(Self {
+            root_dir,
+            root_dev: root_meta.dev(),
+            root_ino: root_meta.ino(),
+        })
+    }
+
+    /// See the module-level docs on [`PathResolver`] for the full contract.
+    pub(crate) fn resolve_parent_identity(&self, path: &Path) -> Result<Option<PathIdentity>> {
+        let to_err = |err| Error::PathIo {
+            path: path.to_owned(),
+            err,
+        };
+
+        let relpath = path.strip_prefix("/").unwrap_or(path);
+        // The leaf is never dereferenced. Paths with no leaf at all (i.e.
+        // "/", or an empty path) fall through to an empty leaf below; such a
+        // path can never match a real entry encountered by the `/var`
+        // walker, so this is harmless.
+        let leaf = relpath.file_name().map(OsString::from).unwrap_or_default();
+        // A bare top-level entry (e.g. "/root") has no parent component to
+        // resolve; the rootfs root itself can't be a symlink, so it (and the
+        // "no leaf at all" case above) resolve directly against the cached
+        // rootfs-root identity.
+        let parent = relpath.parent().unwrap_or_else(|| Path::new(""));
+        if parent.as_os_str().is_empty() {
+            return Ok(Some(PathIdentity::new(self.root_dev, self.root_ino, leaf)));
+        }
+
+        let Some(parent_file) = self.root_dir.open_optional(parent).map_err(to_err)? else {
+            // Some component of the parent doesn't exist: see the docs above
+            // on why `None` is correct here.
+            return Ok(None);
+        };
+        let parent_meta = parent_file.metadata().map_err(to_err)?;
+        Ok(Some(PathIdentity::new(
+            parent_meta.dev(),
+            parent_meta.ino(),
+            leaf,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn newroot() -> Result<cap_std_ext::cap_tempfile::TempDir> {
+        cap_std_ext::cap_tempfile::tempdir(cap_std::ambient_authority()).map_err(Error::Io)
+    }
+
+    /// Create a chain of `n` symlinks named `{prefix}0..{prefix}(n-1)`, each
+    /// pointing to the next, with the last one pointing to a real `target`
+    /// directory (which must already exist).
+    fn make_symlink_chain(rootfs: &Dir, prefix: &str, n: u32) -> Result<()> {
+        for i in 0..n {
+            let target = if i + 1 < n {
+                format!("{prefix}{}", i + 1)
+            } else {
+                "target".to_string()
+            };
+            rootfs.symlink(target, format!("{prefix}{i}"))?;
+        }
+        Ok(())
+    }
+
+    /// Compute the identity that `resolve_parent_identity` *should* return
+    /// for a given `input` path, by directly `fstat`-ing the real, known
+    /// physical location (`expected_parent_relpath`, or `""` for the rootfs
+    /// root itself) in the test fixture. This lets the test assert two
+    /// dynamically-derived values against each other, rather than hardcoding
+    /// meaningless raw `(dev, ino)` numbers.
+    fn expected_identity(rootfs: &Dir, input: &str, expected_parent_relpath: &str) -> PathIdentity {
+        let meta = if expected_parent_relpath.is_empty() {
+            rootfs.dir_metadata().unwrap()
+        } else {
+            rootfs.metadata(expected_parent_relpath).unwrap()
+        };
+        let leaf = Path::new(input).file_name().unwrap_or_default().to_owned();
+        PathIdentity::new(meta.dev(), meta.ino(), leaf)
+    }
+
+    #[test]
+    fn test_resolve_parent_identity() -> anyhow::Result<()> {
+        let rootfs = &newroot()?;
+
+        // No symlinks involved: the path resolves to its own real parent.
+        rootfs.create_dir_all("var/lib/plain")?;
+        // The conventional top-level `/root -> var/roothome` alias.
+        rootfs.create_dir_all("var/roothome/.ssh")?;
+        rootfs.symlink("var/roothome", "root")?;
+        // A symlink nested two levels deep under /var.
+        rootfs.create_dir_all("var/lib/machines")?;
+        rootfs.symlink("machines", "var/lib/portables")?;
+        // An absolute-target top-level symlink (e.g. the conventional
+        // `/home -> /var/home`), proving absolute targets are correctly
+        // chroot-reinterpreted against the rootfs rather than rejected.
+        rootfs.create_dir_all("var/home")?;
+        rootfs.symlink_contents("/var/home", "home")?;
+        // A leaf that is itself a symlink; it must never be dereferenced.
+        rootfs.symlink("var/roothome", "leaf-is-a-symlink")?;
+        // A symlink pointing exactly at the rootfs root, with further
+        // pending components after it that *do* exist, so the successful
+        // resolution path is actually exercised.
+        rootfs.symlink_contents("/", "root-link")?;
+        rootfs.create_dir_all("foo/bar")?;
+        // A chain that switches from a relative target to an absolute one
+        // midway through resolution.
+        rootfs.create_dir_all("c")?;
+        rootfs.symlink("b", "a")?;
+        rootfs.symlink_contents("/c", "b")?;
+        // A dangling intermediate symlink: the target itself doesn't exist
+        // (as opposed to a plain missing path component).
+        rootfs.symlink_contents("/var/nonexistent-target", "var/dangling")?;
+        // A real symlink hop, followed by a path that doesn't exist only
+        // *after* the hop.
+        rootfs.create_dir_all("real")?;
+        rootfs.symlink("real", "alias")?;
+
+        // `expected_parent`, when `Some`, is the rootfs-relative path of the
+        // real physical directory the parent should resolve to (`""` for
+        // the rootfs root itself). `None` means the parent can't be
+        // resolved at all (some component missing), so `Ok(None)` is
+        // expected.
+        let cases: &[(&str, Option<&str>)] = &[
+            // Identity: no symlinks anywhere in the path.
+            ("/var/lib/plain/file", Some("var/lib/plain")),
+            // A single top-level symlink.
+            ("/root/.ssh", Some("var/roothome")),
+            // A symlink nested more than one level deep.
+            ("/var/lib/portables/myimage", Some("var/lib/machines")),
+            // An absolute-target top-level symlink.
+            ("/home/testuser", Some("var/home")),
+            // A dangling/missing intermediate component: nothing on disk,
+            // so no identity can be resolved.
+            ("/nonexistent/deep/path", None),
+            // The leaf itself is a symlink, but must not be dereferenced;
+            // its parent is the rootfs root itself.
+            ("/leaf-is-a-symlink", Some("")),
+            // A symlink pointing exactly at the root, with pending
+            // components after it that fully exist.
+            ("/root-link/foo/bar", Some("foo")),
+            // A relative-then-absolute symlink chain.
+            ("/a/x", Some("c")),
+            // A dangling intermediate symlink: the parent can't be fully
+            // resolved (its target doesn't exist). This is harmless: no
+            // real, physically-walked path can ever match `None`.
+            ("/var/dangling/sub/leaf", None),
+            // A real symlink hop, then a missing component that only
+            // becomes apparent after following it: likewise unresolved.
+            ("/alias/missing/leaf", None),
+        ];
+        let resolver = PathResolver::new(rootfs)?;
+        for (input, expected_parent) in cases.iter().copied() {
+            let resolved = resolver.resolve_parent_identity(Path::new(input))?;
+            let expected = expected_parent.map(|relpath| expected_identity(rootfs, input, relpath));
+            assert_eq!(resolved, expected, "input: {input}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_parent_identity_symlink_loop() -> anyhow::Result<()> {
+        let rootfs = &newroot()?;
+        rootfs.create_dir_all("var")?;
+
+        // A mutual A <-> B loop.
+        rootfs.symlink_contents("/var/b", "var/a")?;
+        rootfs.symlink_contents("/var/a", "var/b")?;
+        let resolver = PathResolver::new(rootfs)?;
+        let err = resolver
+            .resolve_parent_identity(Path::new("/var/a/file"))
+            .unwrap_err();
+        assert!(matches!(err, Error::PathIo { .. }), "{err:?}");
+
+        // A symlink pointing directly at itself.
+        rootfs.symlink("self", "var/self")?;
+        let err = resolver
+            .resolve_parent_identity(Path::new("/var/self/file"))
+            .unwrap_err();
+        assert!(matches!(err, Error::PathIo { .. }), "{err:?}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_parent_identity_chain() -> anyhow::Result<()> {
+        let rootfs = &newroot()?;
+        rootfs.create_dir_all("target")?;
+        // The leaf needs to actually exist, since a chain hop only succeeds
+        // once the *entire* parent (the whole chain) resolves.
+        rootfs.create_dir_all("target/leaf")?;
+
+        // A reasonably long chain of symlinks resolves correctly end to end,
+        // proving multi-hop chains are followed (loop detection itself is
+        // the kernel's job and is covered separately).
+        const CHAIN_LEN: u32 = 25;
+        make_symlink_chain(rootfs, "chain", CHAIN_LEN)?;
+        let resolver = PathResolver::new(rootfs)?;
+        let resolved = resolver.resolve_parent_identity(Path::new("/chain0/leaf/subpath"))?;
+        let expected = expected_identity(rootfs, "/chain0/leaf/subpath", "target/leaf");
+        assert_eq!(resolved, Some(expected));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
It turned out that a systemd version skew caused systemd-tmpfiles to rerun, which created `/root/.ssh` - and that triggered our tmpfiles lint.

We need to handle the symlink aliases more strongly - do that by walking the generated paths and comparing device/inode.

Assisted-by: AI