### PR TITLE
GC UKI and UKI Addons from Composefs Repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -374,7 +374,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "comfy-table",
+ "comfy-table 7.2.2",
  "composefs-ctl",
  "etc-merge",
  "fn-error-context",
@@ -796,6 +796,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "comma"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,8 +813,8 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "composefs"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "composefs-ioctls",
@@ -830,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-boot"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "composefs",
@@ -846,14 +856,14 @@ dependencies = [
 
 [[package]]
 name = "composefs-ctl"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "cap-std-ext",
  "clap",
  "clap_complete",
- "comfy-table",
+ "comfy-table 8.0.0",
  "composefs",
  "composefs-boot",
  "composefs-fuse",
@@ -875,8 +885,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-fuse"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "composefs",
@@ -890,8 +900,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-ioctls"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "rustix",
  "thiserror 2.0.19",
@@ -899,8 +909,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-oci"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -932,8 +942,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-splitdirfdstream"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "openssl",
  "rand 0.10.2",
@@ -945,8 +955,8 @@ dependencies = [
 
 [[package]]
 name = "composefs-storage"
-version = "0.9.0"
-source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.0#90f30e8abbcb5af60421b6b749cbf189b2a8895e"
+version = "0.9.2"
+source = "git+https://github.com/composefs/composefs-rs?tag=v0.9.2#f720d6c79ac6b082fb1e182eed3b291f88e2a7f4"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -2537,7 +2547,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_mangen",
- "comfy-table",
+ "comfy-table 7.2.2",
  "composefs-ctl",
  "containers-image-proxy",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,12 @@ cfg-if = "1.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = "4.5.4"
 clap_mangen = { version = "0.3.0" }
-# To develop against a local composefs-rs checkout, add a [patch] section at the end of this file:
-#   [patch."https://github.com/composefs/composefs-rs"]
-#   composefs-ctl = { path = "/path/to/composefs-rs/crates/composefs-ctl" }
 # The Justfile will auto-detect these and bind-mount them into container builds.
 # The "ostree" feature is disabled for now: it pulls in reqwest (for remote
 # pulls), which drags in rustls-webpki/untrusted/webpki-root-certs whose
 # licenses aren't in our cargo-deny allow list. Re-enable once that's sorted.
 # See: https://github.com/bootc-dev/bootc/pull/2295
-composefs-ctl = { git = "https://github.com/composefs/composefs-rs", tag = "v0.9.0", default-features = false, features = [
+composefs-ctl = { git = "https://github.com/composefs/composefs-rs", tag = "v0.9.2", default-features = false, features = [
     "pre-6.15",
     "pre-6.16",
     "oci",
@@ -88,6 +85,10 @@ tracing-journald = "0.3.1"
 uzers = "0.12"
 linux-kernel-cmdline = { version = "0.1.1", features = ["serde"] }
 xshell = "0.2.6"
+
+# To develop against a local composefs-rs checkout, add a [patch] section at the end of this file:
+# [patch."https://github.com/composefs/composefs-rs"]
+# composefs-ctl = { path = "/composefs-rs/crates/composefs-ctl" }
 
 # See https://github.com/coreos/cargo-vendor-filterer
 [workspace.metadata.vendor-filter]

--- a/crates/lib/src/bootc_composefs/boot.rs
+++ b/crates/lib/src/bootc_composefs/boot.rs
@@ -1615,7 +1615,7 @@ pub(crate) async fn setup_composefs_boot(
     let fs = composefs_oci::image::create_filesystem(
         &*repo,
         &pull_result.config_digest,
-        None,
+        Some(&pull_result.config_verity),
         &Default::default(),
     )
     .context("Creating composefs filesystem for boot entry discovery")?;

--- a/crates/lib/src/bootc_composefs/gc.rs
+++ b/crates/lib/src/bootc_composefs/gc.rs
@@ -494,8 +494,13 @@ pub(crate) async fn composefs_gc(
     // These won't be GC'd by the above `repo.gc` as the EROFS have
     // `/boot` masked
     for verity in all_orphans {
-        let verity_to_sha = Sha512HashValue::from_hex(verity)
-            .with_context(|| anyhow::anyhow!("Bad fsverity {verity}"))?;
+        let verity_to_sha = Sha512HashValue::from_hex(verity);
+
+        let Ok(verity_to_sha) = verity_to_sha else {
+            // We do not want to block on GC if we find corrupted state
+            tracing::warn!("Bad FSVerity '{verity}' when performing GC on orphan, skipping");
+            continue;
+        };
 
         let linked_images = linked_erofs_images(&booted_cfs.repo, &verity_to_sha)
             .with_context(|| anyhow::anyhow!("Getting linked images for {verity}"))?;

--- a/crates/lib/src/bootc_composefs/gc.rs
+++ b/crates/lib/src/bootc_composefs/gc.rs
@@ -12,6 +12,10 @@ use composefs_boot::bootloader::EFI_EXT;
 use composefs_ctl::composefs;
 use composefs_ctl::composefs_boot;
 use composefs_ctl::composefs_oci;
+use ostree_ext::composefs::fsverity::Sha512HashValue;
+use ostree_ext::composefs_oci::linked_erofs_images;
+use rustix::fs::AtFlags;
+use rustix::fs::{statat, unlinkat};
 
 use crate::{
     bootc_composefs::{
@@ -347,7 +351,7 @@ pub(crate) async fn composefs_gc(
 
     // Collect the set of manifest digests referenced by live deployments,
     // and track EROFS image verities as fallback additional_roots for
-    // deployments that predate the manifest→image link.
+    // deployments that predate the manifest -> image link.
     let mut live_manifest_digests: Vec<composefs_oci::OciDigest> = Vec::new();
     let mut additional_roots = Vec::new();
     // Container image names for containers-storage pruning.
@@ -367,7 +371,7 @@ pub(crate) async fn composefs_gc(
         }
 
         // Keep the EROFS image as an additional root until all deployments
-        // have manifest→image refs. Once a deployment is pulled with the
+        // have manifest -> image refs. Once a deployment is pulled with the
         // new code, its EROFS image is reachable from the manifest and
         // this entry becomes redundant (but harmless).
         additional_roots.push(verity.clone());
@@ -484,6 +488,78 @@ pub(crate) async fn composefs_gc(
         }
     }
 
+    let (mut objects_bytes, mut objects_removed) = (0, 0);
+
+    // Now GC the UKI/UKI Addons from `.boot` EROFS if we have them
+    // These won't be GC'd by the above `repo.gc` as the EROFS have
+    // `/boot` masked
+    for verity in all_orphans {
+        let verity_to_sha = Sha512HashValue::from_hex(verity)
+            .with_context(|| anyhow::anyhow!("Bad fsverity {verity}"))?;
+
+        let linked_images = linked_erofs_images(&booted_cfs.repo, &verity_to_sha)
+            .with_context(|| anyhow::anyhow!("Getting linked images for {verity}"))?;
+
+        // Get any image that is non-bootable
+        let Some(non_bootable_img) = linked_images.iter().find(|img| !img.bootable) else {
+            tracing::debug!("No non-bootable image found for {verity}");
+            continue;
+        };
+
+        let boot_dump = composefs_ctl::dump_files(
+            &booted_cfs.repo,
+            &non_bootable_img.id.to_hex(),
+            &vec![std::path::PathBuf::from("/boot")],
+            false,
+        )
+        .context("Getting dump for /boot")?;
+
+        if boot_dump.is_empty() {
+            tracing::debug!("Nothing found in /boot in non-bootable image");
+            continue;
+        }
+
+        let boot_dump = std::str::from_utf8(&boot_dump).context("dumpfile is not UTF-8")?;
+
+        let objects_dir = booted_cfs
+            .repo
+            .objects_dir()
+            .context("Opening objects dir")?;
+
+        use composefs::dumpfile_parse::{Entry, Item};
+
+        for line in boot_dump.lines() {
+            let entry = Entry::parse(line).unwrap();
+
+            let Item::Regular { path, .. } = entry.item else {
+                continue;
+            };
+
+            tracing::debug!(
+                "{}: objects/{path:?}",
+                if gc_opts.dry_run {
+                    "would remove"
+                } else {
+                    "removing"
+                },
+            );
+
+            if gc_opts.dry_run {
+                continue;
+            }
+
+            // Get file size before removing
+            if let Ok(stat) = statat(&objects_dir, path.as_ref(), AtFlags::empty()) {
+                objects_bytes += stat.st_size as u64;
+            }
+
+            objects_removed += 1;
+
+            unlinkat(&objects_dir, path.as_ref(), AtFlags::empty())
+                .with_context(|| format!("Unlinking object {path:?}"))?;
+        }
+    }
+
     // Run garbage collection. Tags root the OCI metadata chain
     // (manifest → config → layers). The additional_roots protect EROFS
     // images for deployments that predate the manifest→image link;
@@ -493,11 +569,14 @@ pub(crate) async fn composefs_gc(
     // first action. Callers must ensure no other `Repository` handle on that
     // same underlying file is still alive when this runs, or it will deadlock
     // (see update.rs's do_upgrade() for an example of getting this wrong).
-    let gc_result = if gc_opts.dry_run {
+    let mut gc_result = if gc_opts.dry_run {
         booted_cfs.repo.gc_dry_run(&additional_roots)?
     } else {
         booted_cfs.repo.gc(&additional_roots)?
     };
+
+    gc_result.objects_bytes += objects_bytes;
+    gc_result.objects_removed += objects_removed;
 
     Ok(gc_result)
 }

--- a/crates/lib/src/bootc_composefs/repo.rs
+++ b/crates/lib/src/bootc_composefs/repo.rs
@@ -407,7 +407,7 @@ pub(crate) async fn pull_composefs_repo(
     let fs = create_composefs_filesystem(
         &*repo,
         &pull_result.config_digest,
-        None,
+        Some(&pull_result.config_verity),
         &Default::default(),
     )
     .context("Creating composefs filesystem for boot entry discovery")?;

--- a/tmt/tests/booted/test-composefs-gc-uki.nu
+++ b/tmt/tests/booted/test-composefs-gc-uki.nu
@@ -36,12 +36,27 @@ def first_boot [] {
 
     bootc switch --transport containers-storage localhost/bootc-first
 
+    # Make sure we have the .boot EROFS
+    let st = bootc status --json | from json
+    let staged_verity = $st.status.staged.composefs.verity
+    let booted_verity = $st.status.booted.composefs.verity
+
     # Find the large file's verity and save it
     let new_st = bootc status --json | from json
     let path = bootc internals cfs dump-files $new_st.status.staged.composefs.verity /usr/share/large-test-file --backing-path-only | awk '{print $2}'
     echo $"/sysroot/composefs/objects/($path)" | save /var/large-file-marker-objpath
 
+    mkdir /var/tmp/efi
+    mount /dev/disk/by-partlabel/EFI-SYSTEM /var/tmp/efi
+
+    # Find the UKI in the objects directory
+    # Intentionally not using the dump-files API here
+    # min/max depth = 1 to not include addons (for now)
+    let uki_sha = sha512sum $"/var/tmp/efi/EFI/Linux/bootc/($uki_prefix)($st.status.booted.composefs.verity).efi" | awk '{print $1}'
+    let uki_in_objs = ^find /sysroot/composefs/objects -type f -exec sha512sum {} + | grep ($uki_sha) | awk '{print $2}'
+
     echo $st.status.booted.composefs.verity | save /var/boot0-verity
+    echo $uki_in_objs | save /var/boot0-uki-in-objs
 
     tmt-reboot
 }
@@ -97,6 +112,9 @@ def third_boot [] {
     echo $containerfile | podman build -t localhost/bootc-third . -f -
 
     bootc switch --transport containers-storage localhost/bootc-third
+
+    # Now also make sure the UKI doesn't exist in the objects directory either
+    assert (not (cat /var/boot0-uki-in-objs | path exists))
 
     tmt-reboot
 }


### PR DESCRIPTION
cfs/gc: GC UKI and UKI Addons

Make use of the non-bootable EROFS to GC everything in the boot
directory of the deployment being GC'd. This is only done for UKI boots
as for normal Type1 booted systems, there should be nothing in /boot

---

tmt: Add tests for .boot images and UKI asset cleanup

Test whether UKI assets are being cleaned up from the objects directory
during GC

---

cfs/filesystem: Pass manifest verity to create_filesystem
There are two reasons to do this

1. We skip the expensive operation of reading every layer and computing
   its hash to preserve integrity.

2. We end up also reading whiteouts in `/boot` which end up erroring out
   since those objects don't exist anymore