### PR TITLE
podstorage: Add early check for missing podman binary

### DIFF
--- a/crates/lib/src/podstorage.rs
+++ b/crates/lib/src/podstorage.rs
@@ -290,6 +290,14 @@ impl CStorage {
         sepolicy: Option<&ostree::SePolicy>,
     ) -> Result<Self> {
         Self::init_globals()?;
+
+        let bin = bootc_utils::podman_bin();
+        if !crate::utils::have_executable(bin)? {
+            anyhow::bail!(
+                "{bin} executable not found in PATH; it is required for container image storage operations"
+            );
+        }
+
         let subpath = &Self::subpath();
 
         // SAFETY: We know there's a parent


### PR DESCRIPTION
When podman is not installed, "No such file or directory (os error 2)" is shown, which users misinterpret as a missing file or directory on disk. 

Before fix:
error: Upgrading: No such file or directory (os error 2)

After fix:
error: Upgrading: Creating imgstorage: nonexistent_podman executable not found in PATH; it is required for container image storage operations

Steps to reproduce:
1. cargo build
2. BOOTC_variant=ostree just build
3. bcvk libvirt run --name bootc-repro --replace --ssh-wait localhost/bootc
4. bcvk libvirt ssh bootc-repro -- 'bash -c "BOOTC_EXP_EXTERNAL_CONTAINER_TOOL=nonexistent_podman bootc upgrade



Closes: https://github.com/bootc-dev/bootc/issues/2284

