### PR TITLE
ci: Update for Fedora 45 branching from rawhide

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,7 +18,7 @@ jobs:
   publish-images:
     strategy:
       matrix:
-        test_os: [fedora-43, fedora-44, fedora-45, centos-9, centos-10]
+        test_os: [fedora-43, fedora-44, fedora-45, fedora-46, centos-9, centos-10]
         variant: [ostree, composefs-sealeduki-sdboot]
         exclude:
           # centos-9 UKI is experimental/broken (https://github.com/bootc-dev/bootc/issues/1812)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
               || [[ "$EVENT" == "pull_request" && "$MERGE_QUEUE_ENABLED" != "true" ]] \
               || echo "$LABELS" | jq -e 'index("ci/merge")' > /dev/null; }; then
             # Full suite: all OSes
-            echo 'package_os_matrix=["fedora-43","fedora-44","fedora-45","centos-9","centos-10"]' >> "$GITHUB_OUTPUT"
+            echo 'package_os_matrix=["fedora-43","fedora-44","fedora-45","fedora-46","centos-9","centos-10"]' >> "$GITHUB_OUTPUT"
             echo 'integration_os_matrix=["fedora-43","fedora-44","centos-9","centos-10"]' >> "$GITHUB_OUTPUT"
             echo 'upgrade_os_matrix=["fedora-44","centos-10"]' >> "$GITHUB_OUTPUT"
             echo 'run_heavy=true' >> "$GITHUB_OUTPUT"
@@ -254,7 +254,7 @@ jobs:
 
     runs-on: ubuntu-24.04
     # Rawhide is best-effort; don't let it block merges
-    continue-on-error: ${{ matrix.test_os == 'fedora-45' }}
+    continue-on-error: ${{ matrix.test_os == 'fedora-46' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -73,6 +73,10 @@ jobs:
       - fedora-44-aarch64
       # s390x disabled: https://github.com/fedora-copr/copr/issues/4219
       # - fedora-44-s390x
+      - fedora-45-x86_64
+      - fedora-45-aarch64
+      # s390x disabled: https://github.com/fedora-copr/copr/issues/4219
+      # - fedora-45-s390x
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
       # Temporarily disabled due to too old Rust...reenable post 9.6
@@ -125,6 +129,8 @@ jobs:
       - fedora-43-aarch64
       - fedora-44-x86_64
       - fedora-44-aarch64
+      - fedora-45-x86_64
+      - fedora-45-aarch64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
     tmt_plan: /tmt/plans/integration

--- a/hack/os-image-map.json
+++ b/hack/os-image-map.json
@@ -9,7 +9,8 @@
     "fedora-42": "quay.io/fedora/fedora-bootc:42",
     "fedora-43": "quay.io/fedora/fedora-bootc:43",
     "fedora-44": "quay.io/fedora/fedora-bootc:44",
-    "fedora-45": "quay.io/fedora/fedora-bootc:45"
+    "fedora-45": "quay.io/fedora/fedora-bootc:45",
+    "fedora-46": "quay.io/fedora/fedora-bootc:46"
   },
   "buildroot-base": {
     "centos-9": "quay.io/centos/centos:stream9",
@@ -17,6 +18,7 @@
     "fedora-42": "quay.io/fedora/fedora:42",
     "fedora-43": "quay.io/fedora/fedora:43",
     "fedora-44": "quay.io/fedora/fedora:44",
-    "fedora-45": "quay.io/fedora/fedora:45"
+    "fedora-45": "quay.io/fedora/fedora:45",
+    "fedora-46": "quay.io/fedora/fedora:46"
   }
 }


### PR DESCRIPTION
Fedora 45 has branched from rawhide, so update the CI matrix
accordingly:

- Add fedora-46 as the new rawhide to os-image-map.json
- Add fedora-46 to package build matrix and build-and-publish
- Add fedora-45 to Packit COPR and TMT test full target sets
- Update continue-on-error rawhide guard from fedora-45 to fedora-46

Intentionally omit fedora-45 from the GHA integration test matrix
for now while it undergoes stabilization, to avoid introducing
additional flaky test failures.

Assisted-by: AI
Closes: #2389
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
