### PR TITLE
Unshare fix for boot.automount

### DIFF
--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1033,7 +1033,14 @@ pub(crate) fn ensure_self_unshared_mount_namespace() -> Result<()> {
             anyhow::bail!("Failed to unshare mount namespace");
         }
     }
-    bootc_utils::reexec::reexec_with_guardenv(recurse_env, &["unshare", "-m", "--"])
+
+    // Pass --propagation=slave so that if systemd gpt-auto-generator has
+    // automount for /boot it gets propagated inside the new mount ns
+    // for us to be able to access the /boot mount even if it's expired
+    bootc_utils::reexec::reexec_with_guardenv(
+        recurse_env,
+        &["unshare", "-m", "--propagation=slave", "--"],
+    )
 }
 
 /// Load global storage state, expecting that we're booted into a bootc system.

--- a/tmt/tests/booted/readonly/054-test-boot-automount.nu
+++ b/tmt/tests/booted/readonly/054-test-boot-automount.nu
@@ -1,0 +1,40 @@
+use tap.nu
+
+# Test if we can still access /boot after it has expired
+
+let automounted = (
+    do { ^findmnt --mountpoint /boot --types autofs --noheadings } | complete
+).exit_code == 0
+
+if not $automounted {
+    print "/boot is not automounted. Exiting"
+    exit 0
+}
+
+$env.SYSTEMD_PAGER = ''
+
+systemctl cat -l boot.automount
+
+bootc status
+
+# Expire boot.autmount
+mkdir /etc/systemd/system/boot.automount.d
+
+echo "
+[Automount]
+TimeoutIdleSec=1
+" | save --force /etc/systemd/system/boot.automount.d/override.conf
+
+systemctl daemon-reload
+systemctl restart boot.automount
+
+print "After overriding timeout"
+systemctl cat -l boot.automount
+
+# Wait for automount to expire
+sleep 5sec
+
+# Make sure bootc status works
+bootc status
+
+tap ok


### PR DESCRIPTION
Pass --propagation=slave so that if systemd gpt-auto-generator has
automount for /boot it gets propagated inside the new mount ns
for us to be able to access the /boot mount even if it's expired

Without this all bootc commands fail with

```
error: Initializing storage: opendir(boot): Operation not permitted
```

Closes: https://github.com/bootc-dev/bootc/issues/2402