### PR TITLE
ci: Pass GitHub token to documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,8 @@ jobs:
         uses: bootc-dev/actions/bootc-ubuntu-setup@main
       - name: Build mdbook
         run: just build-mdbook
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Build packages for each test OS
   package:
     if: needs.compute-ci-level.outputs.run_heavy == 'true'


### PR DESCRIPTION
The pull request documentation job runs cargo-binstall inside a container without authentication, allowing GitHub API rate limits to trigger an unreliable source-build fallback. Pass the workflow token through the existing BuildKit secret path so release downloads use authenticated requests.

Related: https://github.com/bootc-dev/bootc/issues/2177
where i saw failure in latest was here https://github.com/bootc-dev/bootc/actions/runs/33381984257/job/99456194046

This [commit](https://github.com/bootc-dev/bootc/commit/0ee11dbfe21b938a15853675dfcb1c2dcdab48ee) added the fix already but this was missing
Assisted-by: AI