### PR TITLE
Remove condition on existance of /run/ostree-booted for bootc systemd units/timers

### DIFF
--- a/systemd/bootc-fetch-apply-updates.service
+++ b/systemd/bootc-fetch-apply-updates.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Apply bootc updates
 Documentation=man:bootc(8)
-ConditionPathExists=/run/ostree-booted
+ConditionPathExists=|/run/ostree-booted
+ConditionKernelCommandLine=|composefs
 
 [Service]
 Type=oneshot

--- a/systemd/bootc-fetch-apply-updates.timer
+++ b/systemd/bootc-fetch-apply-updates.timer
@@ -1,7 +1,8 @@
 [Unit]
 Description=Apply bootc updates
 Documentation=man:bootc(8)
-ConditionPathExists=/run/ostree-booted
+ConditionPathExists=|/run/ostree-booted
+ConditionKernelCommandLine=|composefs
 
 [Timer]
 OnBootSec=1h


### PR DESCRIPTION
This file is created by ostree backend and won't be present for systems using composefs backend