### PR TITLE
lsm: Use libselinux for process availability

### DIFF
--- a/crates/lib/src/bootc_composefs/selinux.rs
+++ b/crates/lib/src/bootc_composefs/selinux.rs
@@ -121,7 +121,7 @@ pub(crate) fn are_selinux_policies_compatible(
     booted_cmdline: &ComposefsCmdline,
     depl_id: &str,
 ) -> Result<bool> {
-    if !selinux_enabled()? {
+    if !selinux_enabled() {
         return Ok(true);
     }
 

--- a/crates/lib/src/cli.rs
+++ b/crates/lib/src/cli.rs
@@ -1220,7 +1220,7 @@ pub(crate) fn prepare_for_write() -> Result<()> {
     }
     crate::cli::require_root(false)?;
     ensure_self_unshared_mount_namespace()?;
-    if crate::lsm::selinux_enabled()? && !crate::lsm::selinux_ensure_install()? {
+    if crate::lsm::selinux_enabled() && !crate::lsm::selinux_ensure_install()? {
         tracing::debug!("Do not have install_t capabilities");
     }
     ENTERED.store(true, Ordering::SeqCst);
@@ -2318,7 +2318,7 @@ async fn run_from_opt(opt: Opt) -> Result<CliExitStatus> {
                 }
             },
             InternalsOpts::Selinux(SelinuxOpts::IsUnlabeled { path }) => {
-                ensure!(crate::lsm::selinux_enabled()?, "SELinux is not enabled");
+                ensure!(crate::lsm::selinux_enabled(), "SELinux is not enabled");
                 let path = path
                     .strip_prefix("/")
                     .expect("absolute paths have a root prefix");

--- a/crates/lib/src/install.rs
+++ b/crates/lib/src/install.rs
@@ -1381,7 +1381,7 @@ pub(crate) fn reexecute_self_for_selinux_if_needed(
 ) -> Result<SELinuxFinalState> {
     // If the target state has SELinux enabled, we need to check the host state.
     if srcdata.selinux {
-        let host_selinux = crate::lsm::selinux_enabled()?;
+        let host_selinux = crate::lsm::host_selinux_enabled()?;
         tracing::debug!("Target has SELinux, host={host_selinux}");
         let r = if override_disable_selinux {
             println!("notice: Target has SELinux enabled, overriding to disable");

--- a/crates/lib/src/lsm.rs
+++ b/crates/lib/src/lsm.rs
@@ -35,8 +35,20 @@ fn unlabeled_type() -> Result<CString> {
     context_type(context.as_bytes())
 }
 
-#[context("Querying selinux availability")]
-pub(crate) fn selinux_enabled() -> Result<bool> {
+/// Whether SELinux is enabled for the current process.
+///
+/// libselinux caches this state process-wide, so mounting selinuxfs requires a
+/// re-exec before this result can change.
+pub(crate) fn selinux_enabled() -> bool {
+    selinux::kernel_support() != selinux::KernelSupport::Unsupported
+}
+
+/// Whether SELinux is enabled on the host, as observed from PID 1's mount namespace.
+///
+/// This bypasses libselinux's process-cached state and is only appropriate while
+/// bootstrapping the selinuxfs mount before re-exec.
+#[context("Querying host SELinux availability")]
+pub(crate) fn host_selinux_enabled() -> Result<bool> {
     Path::new("/proc/1/root/sys/fs/selinux/enforce")
         .try_exists()
         .map_err(Into::into)
@@ -446,7 +458,9 @@ pub(crate) fn ensure_dir_labeled_recurse(
     use cap_std_ext::dirext::WalkConfiguration;
     use std::ops::ControlFlow;
 
-    let unlabeled_type = selinux_enabled()?.then(unlabeled_type).transpose()?;
+    // When SELinux is unavailable to this process, retain the conservative
+    // xattr-presence behavior in `has_security_selinux_inner`.
+    let unlabeled_type = selinux_enabled().then(unlabeled_type).transpose()?;
     // Juggle the cap-std requirement for relative paths vs the libselinux
     // requirement for absolute paths by special casing the empty string "" as "."
     // just for the initial directory enumeration.

--- a/crates/lib/src/status.rs
+++ b/crates/lib/src/status.rs
@@ -102,7 +102,7 @@ fn check_selinux_policy_compatible(
     target_deployment: &ostree::Deployment,
 ) -> Result<bool> {
     // Only check if SELinux is enabled
-    if !crate::lsm::selinux_enabled()? {
+    if !crate::lsm::selinux_enabled() {
         return Ok(true);
     }
 


### PR DESCRIPTION
Closes: https://github.com/bootc-dev/bootc/issues/2444

Basically us trying to use libselinux more to lookup the unlabeled type breaks in the osbuild scenario where it mounts /sys/fs/selinux readonly, which libselinux treats the same as not existing.

Assisted-by: https://github.com/cgwalters/cgwalters#llms